### PR TITLE
Clean expressions before parsing them

### DIFF
--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -1,8 +1,9 @@
 package hesabu
 
 import (
-	"github.com/Knetic/govaluate"
 	"testing"
+
+	"github.com/Knetic/govaluate"
 )
 
 type ParserTest struct {
@@ -24,8 +25,18 @@ func TestCleaner(t *testing.T) {
 			Expected: "a && b",
 		},
 		{
+			Name:     "Replace and",
+			Input:    "a and b",
+			Expected: "a && b",
+		},
+		{
 			Name:     "Replace OR",
 			Input:    "a OR b",
+			Expected: "a || b",
+		},
+		{
+			Name:     "Replace or",
+			Input:    "a or b",
 			Expected: "a || b",
 		},
 		{
@@ -42,6 +53,16 @@ func TestCleaner(t *testing.T) {
 			Name:     "Replace single = with ==",
 			Input:    "a=b && b     =     c && d = e",
 			Expected: "a==b && b    ==    c && d==e",
+		},
+		{
+			Name:     "Leaves alone variable containing AND",
+			Input:    "operand=1",
+			Expected: "operand==1",
+		},
+		{
+			Name:     "Leaves alone variable containing or",
+			Input:    "operator=1",
+			Expected: "operator==1",
 		},
 	}
 	runEvaluationTests(parserTests, t)

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -1,0 +1,62 @@
+package hesabu
+
+import (
+	"github.com/Knetic/govaluate"
+	"testing"
+)
+
+type ParserTest struct {
+	Name     string
+	Input    string
+	Expected string
+}
+
+func TestCleaner(t *testing.T) {
+	parserTests := []ParserTest{
+		ParserTest{
+			Name:     "Sanity check",
+			Input:    "a + b",
+			Expected: "a + b",
+		},
+		ParserTest{
+			Name:     "Replace AND",
+			Input:    "a AND b",
+			Expected: "a && b",
+		},
+		ParserTest{
+			Name:     "Replace OR",
+			Input:    "a OR b",
+			Expected: "a || b",
+		},
+		ParserTest{
+			Name:     "Leaves <= alone",
+			Input:    "a <= b",
+			Expected: "a <= b",
+		},
+		ParserTest{
+			Name:     "Leaves == alone",
+			Input:    "a == b",
+			Expected: "a == b",
+		},
+		ParserTest{
+			Name:     "Replace single = with ==",
+			Input:    "a=b && b     =     c && d = e",
+			Expected: "a==b && b    ==    c && d==e",
+		},
+	}
+	runEvaluationTests(parserTests, t)
+}
+
+func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
+	functions := map[string]govaluate.ExpressionFunction{}
+	for _, parserTest := range parserTests {
+		equations := map[string]string{"testing": parserTest.Input}
+		parsedEquations := Parse(equations, functions)
+		was := parsedEquations.Equations["testing"].String()
+		if parserTest.Expected != was {
+			t.Logf("Test '%s' '%s' vs '%s'", parserTest.Name, parserTest.Expected, was)
+			t.Fail()
+			continue
+		}
+	}
+}

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -13,32 +13,32 @@ type ParserTest struct {
 
 func TestCleaner(t *testing.T) {
 	parserTests := []ParserTest{
-		ParserTest{
+		{
 			Name:     "Sanity check",
 			Input:    "a + b",
 			Expected: "a + b",
 		},
-		ParserTest{
+		{
 			Name:     "Replace AND",
 			Input:    "a AND b",
 			Expected: "a && b",
 		},
-		ParserTest{
+		{
 			Name:     "Replace OR",
 			Input:    "a OR b",
 			Expected: "a || b",
 		},
-		ParserTest{
+		{
 			Name:     "Leaves <= alone",
 			Input:    "a <= b",
 			Expected: "a <= b",
 		},
-		ParserTest{
+		{
 			Name:     "Leaves == alone",
 			Input:    "a == b",
 			Expected: "a == b",
 		},
-		ParserTest{
+		{
 			Name:     "Replace single = with ==",
 			Input:    "a=b && b     =     c && d = e",
 			Expected: "a==b && b    ==    c && d==e",

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -26,7 +26,7 @@ func randbetweenFunction(args ...interface{}) (interface{}, error) {
 */
 func scoreTableFunction(args ...interface{}) (interface{}, error) {
 	target := args[0].(float64)
-	rules := args[1:len(args)]
+	rules := args[1:]
 	chunkSize := 3
 	for i := 0; i < len(rules); i += chunkSize {
 		end := i + chunkSize

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -1,6 +1,7 @@
 package hesabu
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 
@@ -71,7 +72,12 @@ func absFunction(args ...interface{}) (interface{}, error) {
 
 func ifFunction(args ...interface{}) (interface{}, error) {
 	var result interface{}
-	if args[0].(bool) {
+	bool, ok := args[0].(bool)
+	if !ok {
+		return nil, fmt.Errorf("Expected '%v' to be a boolean expression.", args[0])
+	}
+
+	if bool {
 		result = args[1]
 	} else {
 		result = args[2]

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -19,6 +19,9 @@ func TestGeneric(t *testing.T) {
 		{"min", []interface{}{2.0, 5.0}, 2.0},
 		{"min", []interface{}{-1.0, 5.0}, -1.0},
 		{"min", []interface{}{-1.0, -2.0}, -2.0},
+
+		{"if", []interface{}{true, 9000, 3}, 9000},
+		{"if", []interface{}{false, 2, 9000}, 9000},
 	}
 
 	for _, table := range tables {
@@ -31,5 +34,14 @@ func TestGeneric(t *testing.T) {
 		if result != table.expected {
 			t.Errorf("%s(%v) was incorrect, got: %v, want: %v.", table.functionToCall, table.args, result, table.expected)
 		}
+	}
+}
+
+func TestIfFunctionWithIncorrectBool(t *testing.T) {
+	inputData := []interface{}{1, 2, 3}
+	_, err := Functions()["IF"](inputData...)
+	if err == nil {
+		t.Logf("1 is not a bool, this should have failed")
+		t.Fail()
 	}
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Checking go..."
+which go >/dev/null 2>&1  || {
+    cat <<"GOLANG"
+You need to install Go
+
+Visit https://golang.org/doc/install for instructions
+GOLANG
+    exit 1
+}

--- a/script/build
+++ b/script/build
@@ -1,0 +1,11 @@
+#! /bin/sh
+#
+# Stop on error
+set -e
+
+echo " -> Building"
+
+bindir="${PWD}/bin"
+go build -ldflags="-s -w" -o "${bindir}/hesabucli" hesabu.go
+
+echo " -> New build at: ${bindir}/hesabucli"

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,19 @@
+#! /bin/sh
+#
+# Stop on error
+set -ex
+
+cd "$(dirname "$0")/.."
+
+echo " -> Verifying formatting"
+# Verified using: 'gofmt -s -w  hesabu.go hesabu/*.go'"
+gofmt -s -w hesabu.go hesabu/*.go
+
+git diff --exit-code --quiet || {
+    echo "go fmt changed source files"
+    echo "Please run: gofmt -s -w  hesabu.go hesabu/*.go"
+    exit 1
+}
+
+echo "Running unit tests"
+script/test

--- a/script/test
+++ b/script/test
@@ -1,0 +1,14 @@
+#! /bin/sh
+#
+# Stop on error and output every command before executing it
+set -e
+
+[ -z "$DEBUG" ] || set -x
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+script/build
+
+echo " -> Testing"
+go test ./... -coverprofile=coverage.out

--- a/test/bad_cast.json
+++ b/test/bad_cast.json
@@ -1,0 +1,1 @@
+{"sample_cast_error":"if(1,2,3)"}

--- a/test/good_and_or.json
+++ b/test/good_and_or.json
@@ -1,0 +1,16 @@
+{
+    "a": "1",
+    "b": "2",
+    "c": "3",
+    "d": "4",
+    "e": "5",
+    "a_bool": "a == a",
+    "b_bool": "b == b",
+    "Input":    "a + b",
+    "Input_AND":    "a_bool AND b_bool",
+    "Input_OR":     "a_bool OR b_bool",
+    "untouched_lower": "a <= b",
+    "untouched_equal": "a == b",
+    "equal_and_spaces": "a=b && b     =     c && d = e",
+    "pass": "untouched_lower == true && untouched_equal == false && equal_and_spaces==false && a_bool == true && b_bool == true && Input_AND==true && Input_OR == true"
+}

--- a/test/sample-ug.json
+++ b/test/sample-ug.json
@@ -1,0 +1,578 @@
+{
+  "quantity_hciii_quant01_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant01_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant01_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant01_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant01_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant01_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant02_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant02_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant02_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant02_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant02_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant02_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant03_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant03_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant03_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant03_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant03_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant03_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant04_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant04_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant04_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant04_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant04_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant04_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant05_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant05_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant05_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant05_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant05_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant05_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant06_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant06_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant06_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant06_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant06_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant06_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant07_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant07_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant07_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant07_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant07_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant07_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant08_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant08_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant08_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant08_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant08_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant08_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant09_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant09_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant10_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant10_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant10_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant10_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant10_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant10_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant11_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant11_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant12_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant12_reported_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant12_declared_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant12_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2":
+    "1.0",
+  "quantity_hciii_quant12_validated_for_wmzTMo2sIKx_and_2018q2": "0.0",
+  "quantity_hciii_quant12_validated_is_null_for_wmzTMo2sIKx_and_2018q2": "1.0",
+  "quantity_hciii_quant01_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant01_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant01_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant01_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant01_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant01_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant02_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant02_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant02_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant02_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant02_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant02_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant03_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant03_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant03_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant03_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant03_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant03_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant04_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant04_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant04_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant04_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant04_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant04_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant05_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant05_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant05_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant05_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant05_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant05_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant06_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant06_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant06_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant06_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant06_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant06_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant07_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant07_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant07_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant07_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant07_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant07_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant08_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant08_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant08_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant08_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant08_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant08_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant09_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant09_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant10_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant10_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant10_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant10_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant10_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant10_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant11_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant11_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant12_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant12_reported_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant12_declared_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant12_sample_verified_is_null_for_wmzTMo2sIKx_and_2018":
+    "1.0",
+  "quantity_hciii_quant12_validated_for_wmzTMo2sIKx_and_2018": "0.0",
+  "quantity_hciii_quant12_validated_is_null_for_wmzTMo2sIKx_and_2018": "1.0",
+  "quantity_hciii_quant01_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant01_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant01_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant01_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant01_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant01_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant02_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant02_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant02_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant02_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant02_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant02_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant03_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant03_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant03_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant03_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant03_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant03_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant04_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant04_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant04_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant04_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant04_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant04_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant05_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant05_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant05_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant05_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant05_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant05_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant06_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant06_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant06_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant06_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant06_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant06_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant07_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant07_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant07_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant07_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant07_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant07_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant08_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant08_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant08_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant08_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant08_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant08_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant09_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant09_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant10_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant10_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant10_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant10_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant10_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant10_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant11_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant11_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant12_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant12_reported_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant12_declared_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant12_sample_verified_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quantity_hciii_quant12_validated_for_wmzTMo2sIKx_and_2017july": "0.0",
+  "quantity_hciii_quant12_validated_is_null_for_wmzTMo2sIKx_and_2017july":
+    "1.0",
+  "quality_assessment_for_hciii_qual01_declared_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual01_verified_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_declared_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_verified_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_declared_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_verified_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_declared_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_verified_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_declared_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_verified_points_for_wmzTMo2sIKx_and_2018q2":
+    "0.0",
+  "quality_assessment_for_hciii_qual01_declared_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual01_verified_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_declared_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_verified_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_declared_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_verified_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_declared_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_verified_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_declared_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_verified_points_for_wmzTMo2sIKx_and_2018":
+    "0.0",
+  "quality_assessment_for_hciii_qual01_declared_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual01_verified_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_declared_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual02_verified_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_declared_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual03_verified_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_declared_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual04_verified_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_declared_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quality_assessment_for_hciii_qual05_verified_points_for_wmzTMo2sIKx_and_2017july":
+    "0.0",
+  "quantity_hciii_quant01_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quantity_hciii_quant02_unit_amount_for_wmzTMo2sIKx_and_2018q2": "2000.0",
+  "quantity_hciii_quant03_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quantity_hciii_quant04_unit_amount_for_wmzTMo2sIKx_and_2018q2": "2000.0",
+  "quantity_hciii_quant05_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quantity_hciii_quant06_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quantity_hciii_quant07_unit_amount_for_wmzTMo2sIKx_and_2018q2": "10000.0",
+  "quantity_hciii_quant08_unit_amount_for_wmzTMo2sIKx_and_2018q2": "40000.0",
+  "quantity_hciii_quant09_unit_amount_for_wmzTMo2sIKx_and_2018q2": "6000.0",
+  "quantity_hciii_quant10_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quantity_hciii_quant11_unit_amount_for_wmzTMo2sIKx_and_2018q2": "2500.0",
+  "quantity_hciii_quant12_unit_amount_for_wmzTMo2sIKx_and_2018q2": "4000.0",
+  "quality_assessment_for_hciii_qual01_weight_for_wmzTMo2sIKx_and_2018q2":
+    "25.0",
+  "quality_assessment_for_hciii_qual01_total_point_for_wmzTMo2sIKx_and_2018q2":
+    "31.0",
+  "quality_assessment_for_hciii_qual02_weight_for_wmzTMo2sIKx_and_2018q2":
+    "25.0",
+  "quality_assessment_for_hciii_qual02_total_point_for_wmzTMo2sIKx_and_2018q2":
+    "47.0",
+  "quality_assessment_for_hciii_qual03_weight_for_wmzTMo2sIKx_and_2018q2":
+    "15.0",
+  "quality_assessment_for_hciii_qual03_total_point_for_wmzTMo2sIKx_and_2018q2":
+    "15.0",
+  "quality_assessment_for_hciii_qual04_weight_for_wmzTMo2sIKx_and_2018q2":
+    "10.0",
+  "quality_assessment_for_hciii_qual04_total_point_for_wmzTMo2sIKx_and_2018q2":
+    "24.0",
+  "quality_assessment_for_hciii_qual05_weight_for_wmzTMo2sIKx_and_2018q2":
+    "25.0",
+  "quality_assessment_for_hciii_qual05_total_point_for_wmzTMo2sIKx_and_2018q2":
+    "28.0",
+  "quality_assessment_for_hciii_budget_range1_for_wmzTMo2sIKx_and_2018q2":
+    "1600000.0",
+  "quality_assessment_for_hciii_budget_range2_for_wmzTMo2sIKx_and_2018q2":
+    "2400000.0",
+  "quality_assessment_for_hciii_budget_range3_for_wmzTMo2sIKx_and_2018q2":
+    "3200000.0",
+  "quality_assessment_for_hciii_budget_range4_for_wmzTMo2sIKx_and_2018q2":
+    "4000000.0",
+  "quantity_hciii_quant01_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant01_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant01_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant01_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant01_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant01_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant01_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant01_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant01_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant01_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant01_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant01_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant01_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant01_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant01_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant01_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant01_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant02_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant02_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant02_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant02_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant02_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant02_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant02_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant02_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant02_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant02_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant02_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant02_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant02_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant02_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant02_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant02_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant02_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant03_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant03_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant03_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant03_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant03_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant03_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant03_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant03_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant03_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant03_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant03_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant03_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant03_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant03_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant03_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant03_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant03_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant04_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant04_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant04_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant04_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant04_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant04_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant04_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant04_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant04_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant04_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant04_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant04_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant04_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant04_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant04_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant04_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant04_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant05_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant05_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant05_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant05_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant05_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant05_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant05_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant05_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant05_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant05_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant05_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant05_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant05_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant05_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant05_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant05_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant05_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant06_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant06_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant06_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant06_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant06_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant06_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant06_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant06_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant06_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant06_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant06_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant06_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant06_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant06_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant06_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant06_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant06_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant07_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant07_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant07_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant07_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant07_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant07_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant07_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant07_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant07_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant07_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant07_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant07_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant07_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant07_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant07_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant07_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant07_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant08_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant08_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant08_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant08_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant08_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant08_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant08_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant08_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant08_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant08_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant08_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant08_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant08_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant08_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant08_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant08_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant08_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant09_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant09_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant09_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant09_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant09_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant09_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant09_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant09_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant09_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant09_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant09_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant09_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant09_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant09_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant09_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant09_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant09_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant10_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant10_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant10_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant10_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant10_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant10_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant10_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant10_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant10_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant10_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant10_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant10_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant10_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant10_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant10_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant10_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant10_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant11_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant11_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant11_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant11_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant11_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant11_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant11_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant11_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant11_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant11_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant11_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant11_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant11_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant11_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant11_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant11_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant11_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quant12_amount_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant12_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, quantity_hciii_quant12_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, if((quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(quantity_hciii_quant12_amount_before_verification_for_wmzTMo2sIKx_and_2018q2,2),0)))",
+  "quantity_hciii_quant12_amount_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant12_declared_for_wmzTMo2sIKx_and_2018q2*quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quant12_unit_amount_for_wmzTMo2sIKx_and_2018q2",
+  "quantity_hciii_quant12_amount_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "if(quantity_hciii_quant12_sample_verified_is_null_for_wmzTMo2sIKx_and_2018q2==1 , 0 ,if(quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 10, if(quantity_hciii_quant12_validated_is_null_for_wmzTMo2sIKx_and_2018q2,(quantity_hciii_quant12_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant12_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2)), if((quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003e 10 \u0026\u0026 quantity_hciii_quant12_sample_verified_for_wmzTMo2sIKx_and_2018q2 \u003c= 20),safe_div(if(quantity_hciii_quant12_validated_is_null_for_wmzTMo2sIKx_and_2018q2 ,(quantity_hciii_quant12_verified_for_wmzTMo2sIKx_and_2018q2  *quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2),(quantity_hciii_quant12_validated_for_wmzTMo2sIKx_and_2018q2 *quantity_hciii_quant12_unit_price_for_wmzTMo2sIKx_and_2018q2)),2),0)))",
+  "quantity_hciii_quantity_output_amount_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SUM(quantity_hciii_quant01_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant02_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant03_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant04_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant05_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant06_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant07_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant08_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant09_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant10_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant11_amount_after_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant12_amount_after_verification_for_wmzTMo2sIKx_and_2018q2)",
+  "quantity_hciii_quantity_output_amount_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SUM(quantity_hciii_quant01_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant02_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant03_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant04_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant05_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant06_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant07_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant08_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant09_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant10_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant11_amount_before_verification_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant12_amount_before_verification_for_wmzTMo2sIKx_and_2018q2)",
+  "quantity_hciii_quantity_output_amount_after_val_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SUM(quantity_hciii_quant01_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant02_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant03_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant04_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant05_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant06_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant07_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant08_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant09_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant10_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant11_amount_after_validation_for_wmzTMo2sIKx_and_2018q2, quantity_hciii_quant12_amount_after_validation_for_wmzTMo2sIKx_and_2018q2)",
+  "quality_assessment_for_hciii_qual01_weights_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual01_weight_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual01_total_points_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual01_total_point_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual01_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual01_score_after_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual01_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual01_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual01_score_before_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual01_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual01_score_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual01_declared_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual01_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual01_score_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual01_verified_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual01_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual02_weights_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual02_weight_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual02_total_points_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual02_total_point_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual02_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual02_score_after_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual02_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual02_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual02_score_before_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual02_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual02_score_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual02_declared_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual02_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual02_score_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual02_verified_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual02_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual03_weights_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual03_weight_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual03_total_points_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual03_total_point_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual03_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual03_score_after_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual03_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual03_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual03_score_before_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual03_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual03_score_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual03_declared_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual03_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual03_score_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual03_verified_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual03_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual04_weights_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual04_weight_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual04_total_points_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual04_total_point_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual04_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual04_score_after_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual04_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual04_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual04_score_before_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual04_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual04_score_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual04_declared_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual04_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual04_score_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual04_verified_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual04_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual05_weights_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual05_weight_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual05_total_points_for_wmzTMo2sIKx_and_2018q2":
+    "quality_assessment_for_hciii_qual05_total_point_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual05_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual05_score_after_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual05_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual05_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "(quality_assessment_for_hciii_qual05_score_before_verification_for_wmzTMo2sIKx_and_2018q2/100)*quality_assessment_for_hciii_qual05_weights_for_wmzTMo2sIKx_and_2018q2",
+  "quality_assessment_for_hciii_qual05_score_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual05_declared_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual05_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_qual05_score_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "safe_div(quality_assessment_for_hciii_qual05_verified_points_for_wmzTMo2sIKx_and_2018q2 ,quality_assessment_for_hciii_qual05_total_points_for_wmzTMo2sIKx_and_2018q2 )*100",
+  "quality_assessment_for_hciii_quality_assmnt_score_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SUM(quality_assessment_for_hciii_qual01_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual02_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual03_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual04_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual05_percentage_before_verification_for_wmzTMo2sIKx_and_2018q2)",
+  "quality_assessment_for_hciii_quality_incent_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SCORE_TABLE(quality_assessment_for_hciii_quality_assmnt_score_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2,\r\n0, 65, 0,\r\n65,75, quality_assessment_for_hciii_budget_range1_for_wmzTMo2sIKx_and_2018q2,\r\n75,85, quality_assessment_for_hciii_budget_range2_for_wmzTMo2sIKx_and_2018q2,\r\n85,95, quality_assessment_for_hciii_budget_range3_for_wmzTMo2sIKx_and_2018q2,\r\nquality_assessment_for_hciii_budget_range4_for_wmzTMo2sIKx_and_2018q2)",
+  "quality_assessment_for_hciii_quality_incent_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SCORE_TABLE(quality_assessment_for_hciii_quality_assmnt_score_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2,\r\n0, 65, 0,\r\n65,75, quality_assessment_for_hciii_budget_range1_for_wmzTMo2sIKx_and_2018q2,\r\n75,85, quality_assessment_for_hciii_budget_range2_for_wmzTMo2sIKx_and_2018q2,\r\n85,95, quality_assessment_for_hciii_budget_range3_for_wmzTMo2sIKx_and_2018q2,\r\nquality_assessment_for_hciii_budget_range4_for_wmzTMo2sIKx_and_2018q2)",
+  "quality_assessment_for_hciii_quality_assmnt_score_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2":
+    "SUM(quality_assessment_for_hciii_qual01_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual02_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual03_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual04_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2, quality_assessment_for_hciii_qual05_percentage_after_verification_for_wmzTMo2sIKx_and_2018q2)",
+  "rbf_payment_for_hciii_total_rbf_subsidies_before_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quantity_output_amount_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2  + quality_assessment_for_hciii_quality_incent_before_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2",
+  "rbf_payment_for_hciii_total_rbf_subsidies_after_verification_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quantity_output_amount_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2 +quality_assessment_for_hciii_quality_incent_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2",
+  "rbf_payment_for_hciii_total_rbf_subsidies_after_validation_for_wmzTMo2sIKx_and_2018q2":
+    "quantity_hciii_quantity_output_amount_after_val_for_hciii_for_wmzTMo2sIKx_and_2018q2 + quality_assessment_for_hciii_quality_incent_after_verif_for_hciii_for_wmzTMo2sIKx_and_2018q2"
+}


### PR DESCRIPTION
There can still be legacy formulas that use the old AND, OR and '=' syntax, the clean method will replace this with:

```
      AND => &&
      OR => ||
      = => == (only for equality comparison)
```

This is currently done by the ruby gem, but if this lands in the golang version we can skip doing that in the ruby gem.

While developing this I ran into an issue with the current specs and the `IF`-function, `go fmt` simplified some code and I added some shared scripts to make testing and building easier.
