### PR TITLE
Error out on invalid JSON

### DIFF
--- a/hesabu.go
+++ b/hesabu.go
@@ -29,7 +29,19 @@ func main() {
 		fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
 		return
 	}
-	rawEquations := getEquations()
+	rawEquations, error := getEquations()
+	if error != nil {
+		errs := []hesabu.EvalError{
+			{
+				Message: "Invalid JSON",
+				Source: "general",
+				Expression: "general",
+			},
+		}
+		logErrors(errs)
+		os.Exit(1)
+	}
+
 	parsedEquations := hesabu.Parse(rawEquations, hesabu.Functions())
 	if len(parsedEquations.Errors) > 0 {
 		logErrors(parsedEquations.Errors)
@@ -72,7 +84,7 @@ func logSolution(solutions map[string]interface{}) {
 	fmt.Println(s)
 }
 
-func getEquations() map[string]string {
+func getEquations() (map[string]string, error) {
 	fi, err := os.Stdin.Stat()
 	if err != nil {
 		panic(err)
@@ -96,7 +108,8 @@ func getEquations() map[string]string {
 	err = json.Unmarshal(str, &results)
 	if err != nil {
 		log.Printf("equations not loaded %v ", err)
+		return nil, err
 	}
 	log.Printf("equations loaded: %d ", len(results))
-	return results
+	return results, nil
 }


### PR DESCRIPTION
This was something small that I lost some time on today, I had a JSON
file with:

```
{
  "bad": "if(bb > 9, 2, 2)",
  "bb": "10",
}
```

Which looked to be valid JSON (it is not, see the trailing comma) and
hesabu would give me the following error:

```
  "errors": [
    {
      "source": "general",
      "expression": "general",
      "message": "cycle between equations"
    }
  ]
```

This was caused because the length of the equations was 0 and the
reverse sort of an empty array is an empty array, so we thought we had
a cycle.

I know error earlier to makes this more clear.

I'd like some feedback on how we're going to test this. Do we make a small bash script that just runs through all the json's in our test directory and see if they succeed? That way we have a simple way of knowing if we broke it.