### PR TITLE
A nicer CLI

### DIFF
--- a/hesabu.go
+++ b/hesabu.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -16,8 +18,18 @@ var (
 	date    = "unknown"
 )
 
+var debugFlag = flag.Bool("d", false, "Extra debug logging")
+var versionFlag = flag.Bool("v", false, "Prints version")
+
 func init() {
-	if os.Getenv("HESABU_DEBUG") == "true" {
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
+		os.Exit(0)
+	}
+
+	if os.Getenv("HESABU_DEBUG") == "true" || *debugFlag {
 		log.SetOutput(os.Stderr)
 	} else {
 		log.SetOutput(ioutil.Discard)
@@ -25,16 +37,23 @@ func init() {
 }
 
 func main() {
-	if os.Getenv("HESABU_HELP") == "true" {
-		fmt.Printf("%v, commit %v, built at %v\n", version, commit, date)
-		return
+	raw, error := getInput(flag.Args())
+	if error != nil {
+		fmt.Printf(`
+You need to either supply a filename or pipe to hesabu
+
+      bin/hesabucli path/to/yourfilename.json
+      echo '{"a": "1 + 2 + b", "b": "7"}' | bin/hesabucli
+`)
+		os.Exit(1)
 	}
-	rawEquations, error := getEquations()
+
+	rawEquations, error := getEquations(raw)
 	if error != nil {
 		errs := []hesabu.EvalError{
 			{
-				Message: "Invalid JSON",
-				Source: "general",
+				Message:    "Invalid JSON",
+				Source:     "general",
 				Expression: "general",
 			},
 		}
@@ -84,28 +103,35 @@ func logSolution(solutions map[string]interface{}) {
 	fmt.Println(s)
 }
 
-func getEquations() (map[string]string, error) {
+func getInput(flag_arguments []string) ([]byte, error) {
 	fi, err := os.Stdin.Stat()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	var str []byte
 	if fi.Mode()&os.ModeNamedPipe == 0 {
-		raw, err := ioutil.ReadFile(os.Args[1])
+		if len(flag_arguments) < 1 {
+			return nil, errors.New("No filename supplied")
+		}
+		raw, err := ioutil.ReadFile(flag_arguments[0])
 		if err != nil {
-			panic("file not read" + os.Args[1])
+			return nil, err
 		}
 		str = raw
 	} else {
 		raw, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			panic("pipe not read")
+			return nil, err
 		}
 		str = raw
 	}
-	log.Printf("equations to parse %s", string(str))
+	return str, nil
+}
+
+func getEquations(raw []byte) (map[string]string, error) {
+	log.Printf("equations to parse %s", string(raw))
 	var results map[string]string
-	err = json.Unmarshal(str, &results)
+	err := json.Unmarshal(raw, &results)
 	if err != nil {
 		log.Printf("equations not loaded %v ", err)
 		return nil, err


### PR DESCRIPTION
This adds some flags to the CLI:

-v print version
-d Enable debug

It preserves the original functionality, it still takes a filename or
a pipe, it's just a bit nicer to run manually.

(I was curious about go's flag parsing)