### PR TITLE
Fix inequality

### DIFF
--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -127,8 +127,8 @@ func clean(expression string) (cleanExpression string) {
 	cleanExpression = strings.Replace(cleanExpression, " and ", " && ", -1)
 	cleanExpression = strings.Replace(cleanExpression, " or ", " || ", -1)
 
-	if strings.Contains(expression, "=") {
-		cleanExpression = replaceSingleEquals(expression)
+	if strings.Contains(cleanExpression, "=") {
+		cleanExpression = replaceSingleEquals(cleanExpression)
 	}
 
 	return cleanExpression

--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -159,7 +159,7 @@ func needsCleaning(expression string) bool {
 // third slower than not using a regex.
 func replaceSingleEquals(in string) string {
 	// Characters that combined with an equal form a special symbol
-	reserved := map[byte]int{'=': 1, '<': 1, '>': 1}
+	reserved := map[byte]int{'=': 1, '<': 1, '>': 1, '!': 1}
 	var t = []rune{}
 
 	// Loop over the runes from the in string

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -100,6 +100,11 @@ func TestCleaner(t *testing.T) {
 			Solution: false,
 		},
 		{
+			Name:     "AND and equals",
+			Input:    "(a == 1) AND (b = 2) or (a = 1) || (b == 2)",
+			Expected: "(a == 1) && (b == 2) || (a == 1) || (b == 2)",
+		},
+		{
 			Name:     "Leaves alone variable containing AND",
 			Input:    "operand=1",
 			Expected: "operand==1",

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -15,6 +15,52 @@ type ParserTest struct {
 	Solution             interface{}
 }
 
+func TestCleanerLeavesAlone(t *testing.T) {
+	leave_me_alones := []string{"a<=basic",
+		"a>=basic",
+		"a==basic",
+		"a!=basic",
+		"a <=basic",
+		"a >=basic",
+		"a ==basic",
+		"a!= basic",
+		"a <= basic",
+		"a >= basic",
+		"a == basic",
+		"a != basic",
+		"a<= basic",
+		"a>= basic",
+		"a== basic",
+		"a !=basic"}
+
+	var parserTests []ParserTest
+	for _, leave_me_alone := range leave_me_alones {
+		parserTests = append(parserTests, ParserTest{
+			Name:     leave_me_alone,
+			Input:    leave_me_alone,
+			Expected: leave_me_alone,
+		})
+	}
+	runEvaluationTests(parserTests, t)
+}
+
+func TestCleanerSingleEquals(t *testing.T) {
+	replace_single_equals := map[string]string{
+		"a=b":  "a==b",
+		"a =b": "a ==b",
+		"a= b": "a== b",
+	}
+	var parserTests []ParserTest
+	for input, output := range replace_single_equals {
+		parserTests = append(parserTests, ParserTest{
+			Name:     input,
+			Input:    input,
+			Expected: output,
+		})
+	}
+	runEvaluationTests(parserTests, t)
+}
+
 func TestCleaner(t *testing.T) {
 	parserTests := []ParserTest{
 		{
@@ -48,18 +94,6 @@ func TestCleaner(t *testing.T) {
 			Solution: true,
 		},
 		{
-			Name:     "Leaves <= alone",
-			Input:    "a <= b",
-			Expected: "a <= b",
-			Solution: true,
-		},
-		{
-			Name:     "Leaves == alone",
-			Input:    "a == b",
-			Expected: "a == b",
-			Solution: false,
-		},
-		{
 			Name:     "Replace single = with ==",
 			Input:    "a=b && b     =     c && d = e",
 			Expected: "a==b && b     ==     c && d == e",
@@ -90,11 +124,12 @@ func TestCleaner(t *testing.T) {
 }
 
 func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
-	functions := map[string]govaluate.ExpressionFunction{}
+	functions := Functions() //map[string]govaluate.ExpressionFunction{}
 	for _, parserTest := range parserTests {
 		equations := map[string]string{
 			"abool":   "true",
 			"bbool":   "false",
+			"basic":   "4",
 			"a":       "1",
 			"b":       "2",
 			"testing": parserTest.Input,
@@ -106,7 +141,7 @@ func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
 				t.Logf("err not nil : %s", err)
 			} else {
 				if parserTest.Solution != nil && parserTest.Solution != solution["testing"] {
-					t.Logf("Test '%s' '%F' vs '%s'", parserTest.Name, parserTest.Solution, solution["testing"])
+					t.Logf("Test '%s' '%s' vs '%s'", parserTest.Name, parserTest.Solution, solution["testing"])
 					t.Fail()
 					continue
 				}


### PR DESCRIPTION
Or at least support inequality in the formulas. I was removing the cleaner spec from the Ruby hesabu gem, when I spotted that formulas could also use `!=`, the cleaner version here did not expect this and
would make it `!==`. This fixes that.

It also brings over the other specs from the ruby gem (the cleaner part) that were not addressed by the go tests.