### PR TITLE
Eval array function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## 0.0.4 (unreleased)
+
+- Will now clean the expressions before evaluating them
+
+      There can still be legacy formulas that use the old AND, OR and '='
+      syntax, the clean method will replace this with:
+             AND => &&
+             OR => ||
+             = => == (only for equality comparison)
+
+- Improved test runner and test coverage (Run `script/test` or `script/cibuild` on CI)
+- CLI is a bit more friendly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 ## 0.0.4 (unreleased)
 
+- Add support for two new functions: `array` and `eval_array`
+
+      eval_array('a', (1,2,3), 'b', (2,3,4), 'b - a')
+
+      'a'				=> key 1
+      '(1,2,3)'	=> array 1
+      'b'				=> key 2
+      '(2,3,4)		=> array 2 (needs to be same length as array 1)
+      'b-a'			=> metaformula
+
+      Will loop over the arrays and apply the formula to each index, so
+      in this example would result in:
+
+            (2-1, 3-2,4-3)
+            (1,1,1)
+
+      array(1,2,3,4,5)
+
+      A noop function in this context, mainly added for api parity with
+      dentaku, so arrays can be explicilty marked as arrays.
+
+      ARRAY(1,2,3) => (1,2,3,4,5)
+
+- Add support for profiling (see README for instructions)
 - Will now clean the expressions before evaluating them
 
       There can still be legacy formulas that use the old AND, OR and '='

--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ script/build
 
 Which will generate both a Mac version and a Linux version in the bin folder.
 
+## Profiling
+
+You can run the binary with two additional flags, to enable cpu and memory profiling.
+
+`bin/hesabucli -cpuprofile cpu.prof -memprofile mem.prof test/large_set_of_equations.json`
+
+Now you should have both a cpu.prof and a mem.prof in your directory.
+
+If you now run:
+
+      go tool pprof cpu.prof
+
+You'll be dropped into an interactive profile viewer.
+
+Even more interesting is that you can open an interactive version in you browser with the following:
+
+      pprof -http=localhost:1234 bin/hesabucli cpu.prof
+>>>>>>> d6027d5... Document profiling
+
 ## releasing
 
 have goreleaser https://goreleaser.com/install/

--- a/hesabu.go
+++ b/hesabu.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"runtime"
 	"runtime/pprof"
-	"os"
 
 	"github.com/BLSQ/go-hesabu/hesabu"
 )
@@ -41,14 +41,14 @@ func init() {
 
 	if *cpuprofile != "" {
 		fmt.Printf("o hai there")
-        f, err := os.Create(*cpuprofile)
-        if err != nil {
-            log.Fatal("could not create CPU profile: ", err)
-        }
-        if err := pprof.StartCPUProfile(f); err != nil {
-            log.Fatal("could not start CPU profile: ", err)
-        }
-    }
+		f, err := os.Create(*cpuprofile)
+		if err != nil {
+			log.Fatal("could not create CPU profile: ", err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal("could not start CPU profile: ", err)
+		}
+	}
 }
 
 func main() {

--- a/hesabu.go
+++ b/hesabu.go
@@ -15,9 +15,9 @@ import (
 )
 
 var (
-	version = "dev"
+	version = "0.0.4"
 	commit  = "none"
-	date    = "unknown"
+	date    = "20190121"
 )
 
 var debugFlag = flag.Bool("d", false, "Extra debug logging")

--- a/hesabu.go
+++ b/hesabu.go
@@ -40,7 +40,6 @@ func init() {
 	}
 
 	if *cpuprofile != "" {
-		fmt.Printf("o hai there")
 		f, err := os.Create(*cpuprofile)
 		if err != nil {
 			log.Fatal("could not create CPU profile: ", err)

--- a/hesabu.go
+++ b/hesabu.go
@@ -40,13 +40,7 @@ func init() {
 	}
 
 	if *cpuprofile != "" {
-		f, err := os.Create(*cpuprofile)
-		if err != nil {
-			log.Fatal("could not create CPU profile: ", err)
-		}
-		if err := pprof.StartCPUProfile(f); err != nil {
-			log.Fatal("could not start CPU profile: ", err)
-		}
+		startProfilingCPU(*cpuprofile)
 	}
 }
 
@@ -101,18 +95,11 @@ You need to either supply a filename or pipe to hesabu
 		}
 	}
 
+	stopProfilingCPU()
 	if *memprofile != "" {
-		f, err := os.Create(*memprofile)
-		if err != nil {
-			log.Fatal("could not create memory profile: ", err)
-		}
-		runtime.GC() // get up-to-date statistics
-		if err := pprof.WriteHeapProfile(f); err != nil {
-			log.Fatal("could not write memory profile: ", err)
-		}
-		f.Close()
+		startProfilingMemory(*memprofile)
 	}
-	pprof.StopCPUProfile()
+
 }
 
 func logErrors(errors []hesabu.EvalError) {
@@ -164,4 +151,30 @@ func getEquations(raw []byte) (map[string]string, error) {
 	}
 	log.Printf("equations loaded: %d ", len(results))
 	return results, nil
+}
+
+func startProfilingCPU(fileName string) {
+	f, err := os.Create(fileName)
+	if err != nil {
+		log.Fatal("could not create CPU profile: ", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		log.Fatal("could not start CPU profile: ", err)
+	}
+}
+
+func stopProfilingCPU() {
+	pprof.StopCPUProfile()
+}
+
+func startProfilingMemory(fileName string) {
+	f, err := os.Create(fileName)
+	if err != nil {
+		log.Fatal("could not create memory profile: ", err)
+	}
+	runtime.GC() // get up-to-date statistics
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		log.Fatal("could not write memory profile: ", err)
+	}
+	defer f.Close()
 }

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -15,8 +15,11 @@ type ParserTest struct {
 	Solution             interface{}
 }
 
+// "c": "sum(eval_array('a', e, 'b', (f,0), 'a + b'))"
 func TestEvalArrayFunction(t *testing.T) {
-	leave_me_alones := []string{"sum(eval_array('a', (1,2,3), 'b', (3,4,5), 'a + b'))"}
+	leave_me_alones := []string{"sum(eval_array('a', (1,2,5), 'b', (3,4,5), 'a + b'))",
+		"sum(eval_array('quantity_is_null', (0,1,0,1,0,1), 'stock_is_null', (1,1,0,0,0,1), 'if(quantity_is_null + stock_is_null == 2, 1, 0)'))",
+	}
 	var parserTests []ParserTest
 	for _, leave_me_alone := range leave_me_alones {
 		parserTests = append(parserTests, ParserTest{

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -15,6 +15,20 @@ type ParserTest struct {
 	Solution             interface{}
 }
 
+func TestEvalArrayFunction(t *testing.T) {
+	leave_me_alones := []string{"sum(eval_array('a', (1,2,3), 'b', (3,4,5), 'a + b'))"}
+	var parserTests []ParserTest
+	for _, leave_me_alone := range leave_me_alones {
+		parserTests = append(parserTests, ParserTest{
+			Name:     leave_me_alone,
+			Input:    leave_me_alone,
+			Expected: leave_me_alone,
+			Solution: 18.0,
+		})
+	}
+	runEvaluationTests(parserTests, t)
+}
+
 func TestCleanerLeavesAlone(t *testing.T) {
 	leave_me_alones := []string{"a<=basic",
 		"a>=basic",

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -2,6 +2,7 @@ package hesabu
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"math/rand"
 
@@ -120,6 +121,18 @@ func sumFunction(args ...interface{}) (interface{}, error) {
 	return total, nil
 }
 
+func evalArrayFunction(args ...interface{}) (interface{}, error) {
+	key1 := args[0]
+	array1 := args[1]
+	key2 := args[3]
+	array2 := args[1]
+	meta_formula := args[4].(string)
+
+	// result := meta_formula
+	log.Printf("key 1 %v with %v\nkey2 %v with %v\nsuch meta: %v", key1, array1, key2, array2, meta_formula)
+	return float64(18), nil
+}
+
 func averageFunction(args ...interface{}) (interface{}, error) {
 	total := float64(0)
 	for _, x := range args {
@@ -166,6 +179,7 @@ func Functions() map[string]govaluate.ExpressionFunction {
 		"ROUND":       roundFunction,
 		"randbetween": randbetweenFunction,
 		"RANDBETWEEN": randbetweenFunction,
+		"eval_array" : evalArrayFunction,
 	}
 	return functions
 }

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -8,6 +8,38 @@ import (
 
 	"github.com/Knetic/govaluate"
 )
+var	functions = map[string]govaluate.ExpressionFunction{
+		"strlen":      strlen,
+		"if":          ifFunction,
+		"IF":          ifFunction,
+		"If":          ifFunction,
+		"max":         maxFunction,
+		"MAX":         maxFunction,
+		"Max":         maxFunction,
+		"min":         minFunction,
+		"MIN":         minFunction,
+		"Min":         minFunction,
+		"safe_div":    safeDivFuntion,
+		"SAFE_DIV":    safeDivFuntion,
+		"Safe_div":    safeDivFuntion,
+		"sum":         sumFunction,
+		"SUM":         sumFunction,
+		"Sum":         sumFunction,
+		"avg":         averageFunction,
+		"AVG":         averageFunction,
+		"ABS":         absFunction,
+		"abs":         absFunction,
+		"access":      accessFunction,
+		"ACCESS":      accessFunction,
+		"score_table": scoreTableFunction,
+		"score_Table": scoreTableFunction,
+		"SCORE_TABLE": scoreTableFunction,
+		"round":       roundFunction,
+		"ROUND":       roundFunction,
+		"randbetween": randbetweenFunction,
+		"RANDBETWEEN": randbetweenFunction,
+	}
+
 
 func randbetweenFunction(args ...interface{}) (interface{}, error) {
 	min := args[0].(float64)
@@ -121,16 +153,55 @@ func sumFunction(args ...interface{}) (interface{}, error) {
 	return total, nil
 }
 
+func wrap(arg interface{}) ([]interface {}) {
+	arr, ok := arg.([]interface {})
+	if !ok {
+		arr = make([]interface{}, 1)
+		arr[0] = arg
+	}
+	return arr
+}
+
+var evalExps = 	make(map[string]*govaluate.EvaluableExpression)
+
 func evalArrayFunction(args ...interface{}) (interface{}, error) {
-	key1 := args[0]
-	array1 := args[1]
-	key2 := args[3]
-	array2 := args[1]
+	key1 := args[0].(string)
+	array1 := wrap(args[1])
+	key2 := args[2].(string)
+	array2 := wrap(args[3])
+	if len(array1) != len(array2) {
+		return nil, fmt.Errorf("Expected '%v' and '%v' to have same size of values (%v => %d and %v => %d)", key1, key2, array1, len(array1), array2, len(array2))
+	}
 	meta_formula := args[4].(string)
+	var expression *govaluate.EvaluableExpression
+	var err error
+	if v, aok := evalExps[meta_formula]; aok {
+		expression = v
+	} else {
+		expression, err = govaluate.NewEvaluableExpressionWithFunctions(meta_formula, functions)
+	}
+
+	log.Printf("Expression error %v", err)
+	if err != nil {
+		return nil, err
+	}
+	var results []interface{}
+	for i,item1 := range array1 {
+		item2 := array2[i]
+		parameters := make(map[string]interface{}, 2)
+		parameters[key1] = item1
+		parameters[key2] = item2
+		result, error_eval := expression.Evaluate(parameters)
+		log.Printf("result %v, error_eval %v", result, error_eval)
+		if error_eval != nil {
+			return nil, error_eval
+		}
+		results = append(results, result)
+	}
 
 	// result := meta_formula
-	log.Printf("key 1 %v with %v\nkey2 %v with %v\nsuch meta: %v", key1, array1, key2, array2, meta_formula)
-	return float64(18), nil
+	log.Printf("key 1 %v with %v\nkey2 %v with %v\nsuch meta: %v\nexpression%v", key1, array1, key2, array2, meta_formula, expression)
+	return results, nil
 }
 
 func averageFunction(args ...interface{}) (interface{}, error) {

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -8,38 +8,38 @@ import (
 
 	"github.com/Knetic/govaluate"
 )
-var	functions = map[string]govaluate.ExpressionFunction{
-		"strlen":      strlen,
-		"if":          ifFunction,
-		"IF":          ifFunction,
-		"If":          ifFunction,
-		"max":         maxFunction,
-		"MAX":         maxFunction,
-		"Max":         maxFunction,
-		"min":         minFunction,
-		"MIN":         minFunction,
-		"Min":         minFunction,
-		"safe_div":    safeDivFuntion,
-		"SAFE_DIV":    safeDivFuntion,
-		"Safe_div":    safeDivFuntion,
-		"sum":         sumFunction,
-		"SUM":         sumFunction,
-		"Sum":         sumFunction,
-		"avg":         averageFunction,
-		"AVG":         averageFunction,
-		"ABS":         absFunction,
-		"abs":         absFunction,
-		"access":      accessFunction,
-		"ACCESS":      accessFunction,
-		"score_table": scoreTableFunction,
-		"score_Table": scoreTableFunction,
-		"SCORE_TABLE": scoreTableFunction,
-		"round":       roundFunction,
-		"ROUND":       roundFunction,
-		"randbetween": randbetweenFunction,
-		"RANDBETWEEN": randbetweenFunction,
-	}
 
+var functions = map[string]govaluate.ExpressionFunction{
+	"strlen":      strlen,
+	"if":          ifFunction,
+	"IF":          ifFunction,
+	"If":          ifFunction,
+	"max":         maxFunction,
+	"MAX":         maxFunction,
+	"Max":         maxFunction,
+	"min":         minFunction,
+	"MIN":         minFunction,
+	"Min":         minFunction,
+	"safe_div":    safeDivFuntion,
+	"SAFE_DIV":    safeDivFuntion,
+	"Safe_div":    safeDivFuntion,
+	"sum":         sumFunction,
+	"SUM":         sumFunction,
+	"Sum":         sumFunction,
+	"avg":         averageFunction,
+	"AVG":         averageFunction,
+	"ABS":         absFunction,
+	"abs":         absFunction,
+	"access":      accessFunction,
+	"ACCESS":      accessFunction,
+	"score_table": scoreTableFunction,
+	"score_Table": scoreTableFunction,
+	"SCORE_TABLE": scoreTableFunction,
+	"round":       roundFunction,
+	"ROUND":       roundFunction,
+	"randbetween": randbetweenFunction,
+	"RANDBETWEEN": randbetweenFunction,
+}
 
 func randbetweenFunction(args ...interface{}) (interface{}, error) {
 	min := args[0].(float64)
@@ -153,8 +153,8 @@ func sumFunction(args ...interface{}) (interface{}, error) {
 	return total, nil
 }
 
-func wrap(arg interface{}) ([]interface {}) {
-	arr, ok := arg.([]interface {})
+func wrap(arg interface{}) []interface{} {
+	arr, ok := arg.([]interface{})
 	if !ok {
 		arr = make([]interface{}, 1)
 		arr[0] = arg
@@ -162,7 +162,7 @@ func wrap(arg interface{}) ([]interface {}) {
 	return arr
 }
 
-var evalExps = 	make(map[string]*govaluate.EvaluableExpression)
+var evalExps = make(map[string]*govaluate.EvaluableExpression)
 
 func evalArrayFunction(args ...interface{}) (interface{}, error) {
 	key1 := args[0].(string)
@@ -186,7 +186,7 @@ func evalArrayFunction(args ...interface{}) (interface{}, error) {
 		return nil, err
 	}
 	var results []interface{}
-	for i,item1 := range array1 {
+	for i, item1 := range array1 {
 		item2 := array2[i]
 		parameters := make(map[string]interface{}, 2)
 		parameters[key1] = item1
@@ -250,7 +250,7 @@ func Functions() map[string]govaluate.ExpressionFunction {
 		"ROUND":       roundFunction,
 		"randbetween": randbetweenFunction,
 		"RANDBETWEEN": randbetweenFunction,
-		"eval_array" : evalArrayFunction,
+		"eval_array":  evalArrayFunction,
 	}
 	return functions
 }

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -56,8 +56,8 @@ func TestGeneric(t *testing.T) {
 func TestIfFunctionWithIncorrectBool(t *testing.T) {
 	inputData := []interface{}{1, 2, 3}
 	_, err := Functions()["IF"](inputData...)
-	if err == nil {
-		t.Logf("1 is not a bool, this should have failed")
+	if err, ok := err.(*customFunctionError); !ok {
+		t.Logf("else, %v", err)
 		t.Fail()
 	}
 }

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -38,6 +38,11 @@ func TestGeneric(t *testing.T) {
 
 		{"abs", []interface{}{1.0}, 1.0},
 		{"abs", []interface{}{-1.0}, 1.0},
+
+		{"access", []interface{}{1.0, 2.0, 3.0, 1.0}, 2.0},
+		{"access", []interface{}{1.0, 2.0, 3.0, 2.0}, 3.0},
+
+		{"strlen", []interface{}{"1234567"}, 7.0},
 	}
 
 	for _, table := range tables {

--- a/test/array.json
+++ b/test/array.json
@@ -1,0 +1,4 @@
+{
+    "without_array" : "sum(1,2,3)",
+    "with_array" : "sum(array(1,2,3))"
+}

--- a/test/bad_eval_array.json
+++ b/test/bad_eval_array.json
@@ -1,0 +1,5 @@
+{
+    "e" : "1",
+    "f" :"2",
+    "not-same-length": "sum(eval_array('a', e, 'b', (f,0), 'a + b'))"
+}

--- a/test/eval_array.json
+++ b/test/eval_array.json
@@ -1,5 +1,8 @@
 {
     "e": "1",
     "f": "5",
-    "shouldbe5": "sum(eval_array('a', e, 'b', f, 'a * b'))",
-    "shouldbe2": "sum(eval_array('quantity_is_null', (0,1,0,1,0,1), 'stock_is_null', (1,1,0,0,0,1), 'if(quantity_is_null + stock_is_null == 2, 1, 0)'))",
+    "should_be_5": "sum(eval_array('a', e, 'b', f, 'a * b'))",
+    "should_also_be_5": "sum(eval_array('a', array(e), 'b', array(f), 'a * b'))",
+    "should_be_0": "sum(eval_array('a', array(e,f), 'b', array(1,5), 'b - a'))",
+    "should_be_2": "sum(eval_array('quantity_is_null', array(0,1,0,1,0,1), 'stock_is_null', array(1,1,0,0,0,1), 'if(quantity_is_null + stock_is_null == 2, 1, 0)'))"
+}

--- a/test/eval_array.json
+++ b/test/eval_array.json
@@ -1,0 +1,5 @@
+{
+    "e": "1",
+    "f": "5",
+    "shouldbe5": "sum(eval_array('a', e, 'b', f, 'a * b'))",
+    "shouldbe2": "sum(eval_array('quantity_is_null', (0,1,0,1,0,1), 'stock_is_null', (1,1,0,0,0,1), 'if(quantity_is_null + stock_is_null == 2, 1, 0)'))",

--- a/test/example_runners.sh
+++ b/test/example_runners.sh
@@ -15,7 +15,7 @@ for name in test/bad_*.json
 do
     if bin/hesabucli $name >/dev/null 2>&1
     then
-        $its_all_good=1
+        its_all_good=1
         echo "${name} \033[1;31mFAIL\033[0m"
     else
         echo "${name} \033[1;32mPASS\033[0m"
@@ -28,14 +28,16 @@ do
     then
         echo "${name} \033[1;32mPASS\033[0m"
     else
-        $its_all_good=1
+        its_all_good=1
         echo "${name} \033[1;31mFAIL\033[0m"
     fi
 done
 
 if [ "${its_all_good}" -gt "0" ]
 then
-    echo "Some examples are failing"
+    echo "\n\033[1;31mSome examples are failing\033[0m"
+else
+    echo "\n\033[1;32mIt's all good\033[0m"
 fi
 
 exit $its_all_good


### PR DESCRIPTION
- Add support for two new functions: `array` and `eval_array`

      eval_array('a', (1,2,3), 'b', (2,3,4), 'b - a')

      'a'				=> key 1
      '(1,2,3)'	=> array 1
      'b'				=> key 2
      '(2,3,4)		=> array 2 (needs to be same length as array 1)
      'b-a'			=> metaformula

      Will loop over the arrays and apply the formula to each index, so
      in this example would result in:

            (2-1, 3-2,4-3)
            (1,1,1)

      array(1,2,3,4,5)

      A noop function in this context, mainly added for api parity with
      dentaku, so arrays can be explicilty marked as arrays.

      ARRAY(1,2,3) => (1,2,3,4,5)

- Add support for profiling (see README for instructions)

(this also adds a changelog, and proposes a new version number when this gets released)