### PR TITLE
Add support for arrays as variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ You'll be dropped into an interactive profile viewer.
 Even more interesting is that you can open an interactive version in you browser with the following:
 
       pprof -http=localhost:1234 bin/hesabucli cpu.prof
->>>>>>> d6027d5... Document profiling
 
 ## releasing
 

--- a/hesabu.go
+++ b/hesabu.go
@@ -74,33 +74,25 @@ You need to either supply a filename or pipe to hesabu
 	if len(parsedEquations.Errors) > 0 {
 		logErrors(parsedEquations.Errors)
 		os.Exit(1)
-	} else {
-		solutions, err := parsedEquations.Solve()
-		if err != nil {
-			var evalErrors []hesabu.EvalError
-			var hesabuerr hesabu.EvalError
+	}
 
-			ok, err2 := err.(*hesabu.CustomError)
-			if !err2 {
-				panic("ddd")
-			}
-			if ok != nil {
-				hesabuerr = ok.EvalError
-			}
-
-			evalErrors = append(evalErrors, hesabuerr)
-			logErrors(evalErrors)
+	solutions, err := parsedEquations.Solve()
+	if err != nil {
+		if customError, ok := err.(*hesabu.CustomError); ok {
+			evalError := customError.EvalError
+			logErrors([]hesabu.EvalError{evalError})
 			os.Exit(1)
 		} else {
-			logSolution(solutions)
+			panic("Only expected a custom error")
 		}
 	}
+
+	logSolution(solutions)
 
 	stopProfilingCPU()
 	if *memprofile != "" {
 		startProfilingMemory(*memprofile)
 	}
-
 }
 
 func logErrors(errors []hesabu.EvalError) {

--- a/hesabu.go
+++ b/hesabu.go
@@ -24,6 +24,7 @@ var debugFlag = flag.Bool("d", false, "Extra debug logging")
 var versionFlag = flag.Bool("v", false, "Prints version")
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile to `file`")
 var memprofile = flag.String("memprofile", "", "write memory profile to `file`")
+var ShouldLog = false
 
 func init() {
 	flag.Parse()
@@ -34,9 +35,9 @@ func init() {
 	}
 
 	if os.Getenv("HESABU_DEBUG") == "true" || *debugFlag {
+		ShouldLog = true
+		hesabu.ShouldLog = ShouldLog
 		log.SetOutput(os.Stderr)
-	} else {
-		log.SetOutput(ioutil.Discard)
 	}
 
 	if *cpuprofile != "" {
@@ -142,14 +143,18 @@ func getInput(flag_arguments []string) ([]byte, error) {
 }
 
 func getEquations(raw []byte) (map[string]string, error) {
-	log.Printf("equations to parse %s", string(raw))
 	var results map[string]string
 	err := json.Unmarshal(raw, &results)
 	if err != nil {
-		log.Printf("equations not loaded %v ", err)
+		if ShouldLog {
+			log.Printf("equations to parse %s", string(raw))
+			log.Printf("equations not loaded %v ", err)
+		}
 		return nil, err
 	}
-	log.Printf("equations loaded: %d ", len(results))
+	if ShouldLog {
+		log.Printf("equations loaded: %d ", len(results))
+	}
 	return results, nil
 }
 

--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -67,15 +67,17 @@ func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
 	solutions := make(map[string]interface{}, len(parsedEquations.RawEquations))
 	if len(topsort) == 0 {
 		evalError := EvalError{Message: "cycle between equations", Source: "general", Expression: "general"}
-		return make(map[string]interface{}), &CustomError{EvalError: evalError}
+		return nil, &CustomError{EvalError: evalError}
 	}
 
 	for _, key := range topsort {
 		expression, ok := parsedEquations.Equations[key]
 		if !ok {
-			// Should we already bail here?
-			// The solve won't work because we're missing a parameter.
-			log.Printf("[%s] was never defined", key)
+			return nil, &EvalError{
+				Message:    fmt.Sprintf("%s was never defined", key),
+				Source:     key,
+				Expression: "",
+			}
 			continue
 		}
 
@@ -104,7 +106,7 @@ func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
 func (parsedEquations ParsedEquations) newSingleError(key string, message string) (map[string]interface{}, error) {
 	equation := parsedEquations.RawEquations[key]
 	evalError := EvalError{Message: message, Source: key, Expression: equation}
-	return make(map[string]interface{}), &CustomError{EvalError: evalError}
+	return nil, &CustomError{EvalError: evalError}
 }
 
 func isNumeric(s string) bool {

--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -73,10 +73,12 @@ func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
 	for _, key := range topsort {
 		expression, ok := parsedEquations.Equations[key]
 		if !ok {
-			return nil, &EvalError{
-				Message:    fmt.Sprintf("%s was never defined", key),
-				Source:     key,
-				Expression: "",
+			return nil, &CustomError{
+				EvalError: EvalError{
+					Message:    fmt.Sprintf("%s was never defined", key),
+					Source:     key,
+					Expression: "",
+				},
 			}
 			continue
 		}

--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -28,6 +28,8 @@ func (e *CustomError) Error() string {
 	return e.EvalError.Error()
 }
 
+var ShouldLog = false
+
 // Eval or parsing errors
 type EvalError struct {
 	Source     string `json:"source"`
@@ -52,7 +54,6 @@ func Parse(rawEquations map[string]string, functions map[string]govaluate.Expres
 			errorsCollector = append(errorsCollector, EvalError{Source: key, Message: err.Error(), Expression: exp})
 		} else {
 			equations[key] = *expression
-			log.Printf("vars  %v", expression.Vars())
 			equationDependencies[key] = expression.Vars()
 		}
 	}

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -285,12 +285,9 @@ func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
 	}
 }
 
-// Without Clean						: BenchmarkParse-4   	      10	 165449475 ns/op
-// With replaceSingleEqual  : BenchmarkParse-4   	      10	 188343765 ns/op
-// With regex								: BenchmarkParse-4   	       5	 318208619 ns/op
 func BenchmarkParse(b *testing.B) {
-	functions := map[string]govaluate.ExpressionFunction{}
-	raw, err := ioutil.ReadFile("../test/large_set_of_equations.json")
+	functions := Functions()
+	raw, err := ioutil.ReadFile("../test/very_large_set_of_equations.json")
 	if err != nil {
 		panic("file not read")
 	}
@@ -300,8 +297,28 @@ func BenchmarkParse(b *testing.B) {
 		panic("Could not read JSON")
 	}
 	b.ResetTimer()
-	// run the Fib function b.N times
 	for n := 0; n < b.N; n++ {
 		Parse(equations, functions)
+	}
+}
+
+func BenchmarkSolve(b *testing.B) {
+	functions := Functions()
+	raw, err := ioutil.ReadFile("../test/very_large_set_of_equations.json")
+	if err != nil {
+		panic("file not read")
+	}
+	var equations map[string]string
+	err = json.Unmarshal(raw, &equations)
+	if err != nil {
+		panic("Could not read JSON")
+	}
+	parsedEquations := Parse(equations, functions)
+	if len(parsedEquations.Errors) > 0 {
+		panic("Error while parsing")
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		parsedEquations.Solve()
 	}
 }

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -285,6 +285,19 @@ func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
 	}
 }
 
+func TestUnboundVariables(t *testing.T) {
+	functions := Functions()
+	equations := map[string]string{
+		"result": "a + b + c",
+	}
+	parsedEquations := Parse(equations, functions)
+	_, err := parsedEquations.Solve()
+	if _, ok := err.(*EvalError); !ok {
+		t.Logf("Expected an eval error because a, b and c were never defined")
+		t.Fail()
+	}
+}
+
 func BenchmarkParse(b *testing.B) {
 	functions := Functions()
 	raw, err := ioutil.ReadFile("../test/very_large_set_of_equations.json")

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -292,7 +292,7 @@ func TestUnboundVariables(t *testing.T) {
 	}
 	parsedEquations := Parse(equations, functions)
 	_, err := parsedEquations.Solve()
-	if _, ok := err.(*EvalError); !ok {
+	if _, ok := err.(*CustomError); !ok {
 		t.Logf("Expected an eval error because a, b and c were never defined")
 		t.Fail()
 	}

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -2,7 +2,6 @@ package hesabu
 
 import (
 	"encoding/json"
-	"github.com/Knetic/govaluate"
 	"io/ioutil"
 	"testing"
 )
@@ -32,6 +31,49 @@ func TestArrayFunction(t *testing.T) {
 	runEvaluationTests(testCases, t)
 }
 
+func TestVariableAsArray(t *testing.T) {
+	functions := Functions() //map[string]govaluate.ExpressionFunction{}
+	equations := map[string]string{
+		"a":      "array(1,2,-3,4,5)",
+		"sum":    "sum(a)",
+		"max":    "max(a)",
+		"min":    "min(a)",
+		"avg":    "avg(a)",
+		"access": "access(a,1)",
+	}
+	parsedEquations := Parse(equations, functions)
+	if len(parsedEquations.Errors) > 0 {
+		t.Logf("Did not expect any errors while parsing: %v", parsedEquations.Errors)
+		t.Fail()
+	}
+
+	solution, err := parsedEquations.Solve()
+	if err != nil {
+		t.Logf("Did not expect an error: %s", err)
+		t.Fail()
+	}
+	if solution["sum"] != (1 + 2 + -3.0 + 4.0 + 5.0) {
+		t.Logf("Solution does not match our sum: %f", solution["sum"])
+		t.Fail()
+	}
+	if solution["max"] != 5.0 {
+		t.Logf("Solution does not match our max: %f", solution["max"])
+		t.Fail()
+	}
+	if solution["min"] != -3.0 {
+		t.Logf("Solution does not match our min: %f", solution["min"])
+		t.Fail()
+	}
+	if solution["avg"] != 1.8 {
+		t.Logf("Solution does not match our avg: %f", solution["avg"])
+		t.Fail()
+	}
+	if solution["access"] != 2.0 {
+		t.Logf("Solution does not match our access: %f", solution["access"])
+		t.Fail()
+	}
+}
+
 func TestEvalArrayFunction(t *testing.T) {
 	testCases := []ParserTest{
 		{
@@ -48,6 +90,11 @@ func TestEvalArrayFunction(t *testing.T) {
 			Name:     "More complex",
 			Input:    "sum(eval_array('quantity_is_null', (0,1,0,1,0,1), 'stock_is_null', (1,1,0,0,0,1), 'if(quantity_is_null + stock_is_null == 2, 1, 0)'))",
 			Solution: 2.0,
+		},
+		{
+			Name:     "Can handle negative numbers",
+			Input:    "sum(eval_array('a', (1,-2,5), 'b', (3,4,-5), 'a - b'))",
+			Solution: (1.0 - 3.0 + -2.0 - 4.0 + 5.0 - -5.0),
 		},
 		{
 			Name:          "Malformed formulas return an error",
@@ -181,6 +228,9 @@ func runEvaluationTests(parserTests []ParserTest, t *testing.T) {
 			"basic":   "4",
 			"a":       "1",
 			"b":       "2",
+			"c":       "4",
+			"d":       "5",
+			"e":       "6",
 			"testing": parserTest.Input,
 		}
 		parsedEquations := Parse(equations, functions)

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -164,8 +164,15 @@ func minFunction(args ...interface{}) (interface{}, error) {
 
 func sumFunction(args ...interface{}) (interface{}, error) {
 	total := float64(0.0)
-	for _, arg := range args {
-		total += arg.(float64)
+	for _, a := range args {
+		if v, ok := a.(float64); ok {
+			total += v
+		} else {
+			return nil, &customFunctionError{
+				functionName: "sumFunction",
+				err:          fmt.Sprintf("Unspoorted type to sum: %T", v),
+			}
+		}
 	}
 	return total, nil
 }

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -67,6 +67,15 @@ func TestIfFunctionWithIncorrectBool(t *testing.T) {
 	}
 }
 
+func TestSumFunctionWithIncorrectValues(t *testing.T) {
+	inputData := []interface{}{"a", "b", "c"}
+	_, err := Functions()["SUM"](inputData...)
+	if err, ok := err.(*customFunctionError); !ok {
+		t.Logf("else, %v", err)
+		t.Fail()
+	}
+}
+
 func TestRandBetweenFunction(t *testing.T) {
 	inputData := []interface{}{1.0, 10.0}
 	value, err := Functions()["randbetween"](inputData...)

--- a/script/bench
+++ b/script/bench
@@ -1,0 +1,15 @@
+#! /bin/sh
+#
+# Stop on error and output every command before executing it
+set -e
+
+[ -z "$DEBUG" ] || set -x
+
+cd "$(dirname "$0")/.."
+
+script/bootstrap
+script/build
+
+echo " -> Benchmarking"
+echo "    (+- 8s on a MacBook, +- 10s on Travis)"
+go test -bench=. ./...

--- a/script/cibuild
+++ b/script/cibuild
@@ -19,3 +19,6 @@ script/test
 
 echo "Running examples"
 sh test/example_runners.sh
+
+echo "Running benchmarks"
+script/bench

--- a/test/example_runners.sh
+++ b/test/example_runners.sh
@@ -11,9 +11,14 @@ set -e
 
 its_all_good=0
 
+cli=bin/hesabucli
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    cli=bin/hesabucli-mac
+fi
+
 for name in test/bad_*.json
 do
-    if bin/hesabucli $name >/dev/null 2>&1
+    if $cli $name >/dev/null 2>&1
     then
         its_all_good=1
         echo "${name} \033[1;31mFAIL\033[0m"
@@ -24,7 +29,7 @@ done
 
 for name in $(ls -1 test/*.json | grep -v 'bad_')
 do
-    if bin/hesabucli $name >/dev/null 2>&1
+    if $cli $name >/dev/null 2>&1
     then
         echo "${name} \033[1;32mPASS\033[0m"
     else


### PR DESCRIPTION
*NOTE* Very much in flux.

End goal is to have this working:

`❯ echo '{"a": "array(1,2)", "c": "(3,4)", "b": "sum(a)", "d": "sum(c)"}' | bin/hesabucli-mac -d`

```
{
  "a": [
    1,
    2
  ],
  "b": 3,
  "c": [
    1,
    2
  ],
  "d": 3
}
```