### PR TITLE
Add additional error handling

### DIFF
--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -69,6 +69,11 @@ func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
 		return nil, &CustomError{EvalError: evalError}
 	}
 
+	if len(topsort) != len(parsedEquations.RawEquations) {
+		evalError := EvalError{Message: "Topological sort not same length as inputted equations", Source: "general", Expression: "general"}
+		return nil, &CustomError{EvalError: evalError}
+	}
+
 	for _, key := range topsort {
 		expression, ok := parsedEquations.Equations[key]
 		if !ok {

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -104,8 +104,23 @@ func scoreTableFunction(args ...interface{}) (interface{}, error) {
 	return args[0], nil
 }
 
+// access(ARRAY(1,2,3), 0) => 1
+//
+// Due the way we're getting the `args`, everything is just one array,
+// we use the last element as the requested index, this also means:
+//
+// access(ARRAY(1,2,0)) => 1
+//
+// If the index is out of range an error will be returned.
 func accessFunction(args ...interface{}) (interface{}, error) {
 	index := int(args[len(args)-1].(float64))
+	if index > len(args)-1 {
+		return nil, &customFunctionError{
+			functionName: "ACCESS",
+			err:          fmt.Sprintf("Tried to access element at index %v in  '%v'.", args[len(args)-1], args[0:len(args)-1]),
+		}
+	}
+
 	return args[index], nil
 }
 

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -131,3 +131,12 @@ func TestBothUpperCaseAndLowerCaseVariantsAreFound(t *testing.T) {
 		}
 	}
 }
+
+func TestAccessOutOfRangeError(t *testing.T) {
+	inputData := []interface{}{1.0, 2.0, 8.0}
+	_, err := Functions()["access"](inputData...)
+	if err, ok := err.(*customFunctionError); !ok {
+		t.Logf("else, %v", err)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
The ruby gem probably covers the access function check as well, but in case it doesn't this provides an extra layer.

This also cleans up the error where in some rare cases the topological sort isn't the same length as the input (which we've had happen and it causes weird problems further down the line)