### PR TITLE
TRUNC, CEILING and FLOOR functions

### DIFF
--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -130,14 +130,27 @@ func accessFunction(args ...interface{}) (interface{}, error) {
 	return args[index], nil
 }
 
-func roundFunction(args ...interface{}) (interface{}, error) {
+func getShiftPlaces(args []interface{}) float64 {
 	places := 0
 	if len(args) == 2 {
 		places = int(args[1].(float64))
 	}
-	f := args[0].(float64)
 
 	shift := math.Pow(10, float64(places))
+	return shift
+}
+
+func getMultiple(args []interface{}) float64 {
+	multiple := 1.0
+	if len(args) == 2 {
+		multiple = args[1].(float64)
+	}
+	return multiple
+}
+
+func roundFunction(args ...interface{}) (interface{}, error) {
+	shift := getShiftPlaces(args)
+	f := args[0].(float64)
 	return (math.Round(f*shift) / shift), nil
 }
 
@@ -145,10 +158,7 @@ func roundFunction(args ...interface{}) (interface{}, error) {
 // by default floor to nearest multiple of 1.0
 // but can be passed as an optional argument
 func floorFunction(args ...interface{}) (interface{}, error) {
-	multiple := 1.0
-	if len(args) == 2 {
-		multiple = args[1].(float64)
-	}
+	multiple := getMultiple(args)
 	f := args[0].(float64)
 	return (math.Floor(f/multiple) * multiple), nil
 }
@@ -157,10 +167,7 @@ func floorFunction(args ...interface{}) (interface{}, error) {
 // by default ceil to nearest multiple of 1.0
 // but can be passed as an optional argument
 func ceilingFunction(args ...interface{}) (interface{}, error) {
-	multiple := 1.0
-	if len(args) == 2 {
-		multiple = args[1].(float64)
-	}
+	multiple := getMultiple(args)
 	f := args[0].(float64)
 	return (math.Ceil(f/multiple) * multiple), nil
 }
@@ -169,13 +176,8 @@ func ceilingFunction(args ...interface{}) (interface{}, error) {
 // by default 0 digits after the decimal
 // but can passed an optional argument to ask for more
 func truncFunction(args ...interface{}) (interface{}, error) {
-	places := 0
-	if len(args) == 2 {
-		places = int(args[1].(float64))
-	}
+	shift := getShiftPlaces(args)
 	f := args[0].(float64)
-
-	shift := math.Pow(10, float64(places))
 	return (float64(int(f*shift)) / shift), nil
 }
 

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -50,8 +50,8 @@ var functions = map[string]govaluate.ExpressionFunction{
 	"round":       roundFunction,
 	"FLOOR":       floorFunction,
 	"floor":       floorFunction,
-	"CEIL":        ceilFunction,
-	"ceil":        ceilFunction,
+	"CEILING":     ceilingFunction,
+	"ceiling":     ceilingFunction,
 	"SAFE_DIV":    safeDivFuntion,
 	"Safe_div":    safeDivFuntion,
 	"safe_div":    safeDivFuntion,
@@ -139,6 +139,9 @@ func roundFunction(args ...interface{}) (interface{}, error) {
 	return (math.Round(f*shift) / shift), nil
 }
 
+// mimic FLOOR https://support.office.com/en-us/article/floor-function-14bb497c-24f2-4e04-b327-b0b4de5a8886
+// by default floor to nearest multiple of 1.0
+// but can be passed as an optional argument
 func floorFunction(args ...interface{}) (interface{}, error) {
 	multiple := 1.0
 	if len(args) == 2 {
@@ -148,7 +151,10 @@ func floorFunction(args ...interface{}) (interface{}, error) {
 	return (math.Floor(f/multiple) * multiple), nil
 }
 
-func ceilFunction(args ...interface{}) (interface{}, error) {
+// CEILING https://support.office.com/en-us/article/ceiling-function-0a5cd7c8-0720-4f0a-bd2c-c943e510899f
+// by default ceil to nearest multiple of 1.0
+// but can be passed as an optional argument
+func ceilingFunction(args ...interface{}) (interface{}, error) {
 	multiple := 1.0
 	if len(args) == 2 {
 		multiple = args[1].(float64)

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -131,21 +131,18 @@ func accessFunction(args ...interface{}) (interface{}, error) {
 }
 
 func getShiftPlaces(args []interface{}) float64 {
-	places := 0
-	if len(args) == 2 {
-		places = int(args[1].(float64))
-	}
+	places := int(getSecondArgsAsFloat(args, 0.0))
 
 	shift := math.Pow(10, float64(places))
 	return shift
 }
 
-func getMultiple(args []interface{}) float64 {
-	multiple := 1.0
+func getSecondArgsAsFloat(args []interface{}, defaultValue float64) float64 {
+	value := defaultValue
 	if len(args) == 2 {
-		multiple = args[1].(float64)
+		value = args[1].(float64)
 	}
-	return multiple
+	return value
 }
 
 func roundFunction(args ...interface{}) (interface{}, error) {
@@ -158,7 +155,7 @@ func roundFunction(args ...interface{}) (interface{}, error) {
 // by default floor to nearest multiple of 1.0
 // but can be passed as an optional argument
 func floorFunction(args ...interface{}) (interface{}, error) {
-	multiple := getMultiple(args)
+	multiple := getSecondArgsAsFloat(args, 1.0)
 	f := args[0].(float64)
 	return (math.Floor(f/multiple) * multiple), nil
 }
@@ -167,7 +164,7 @@ func floorFunction(args ...interface{}) (interface{}, error) {
 // by default ceil to nearest multiple of 1.0
 // but can be passed as an optional argument
 func ceilingFunction(args ...interface{}) (interface{}, error) {
-	multiple := getMultiple(args)
+	multiple := getSecondArgsAsFloat(args, 1.0)
 	f := args[0].(float64)
 	return (math.Ceil(f/multiple) * multiple), nil
 }

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -48,6 +48,10 @@ var functions = map[string]govaluate.ExpressionFunction{
 	"randbetween": randbetweenFunction,
 	"ROUND":       roundFunction,
 	"round":       roundFunction,
+	"FLOOR":       floorFunction,
+	"floor":       floorFunction,
+	"CEIL":        ceilFunction,
+	"ceil":        ceilFunction,
 	"SAFE_DIV":    safeDivFuntion,
 	"Safe_div":    safeDivFuntion,
 	"safe_div":    safeDivFuntion,
@@ -130,8 +134,27 @@ func roundFunction(args ...interface{}) (interface{}, error) {
 		places = int(args[1].(float64))
 	}
 	f := args[0].(float64)
+
 	shift := math.Pow(10, float64(places))
 	return (math.Round(f*shift) / shift), nil
+}
+
+func floorFunction(args ...interface{}) (interface{}, error) {
+	multiple := 1.0
+	if len(args) == 2 {
+		multiple = args[1].(float64)
+	}
+	f := args[0].(float64)
+	return (math.Floor(f/multiple) * multiple), nil
+}
+
+func ceilFunction(args ...interface{}) (interface{}, error) {
+	multiple := 1.0
+	if len(args) == 2 {
+		multiple = args[1].(float64)
+	}
+	f := args[0].(float64)
+	return (math.Ceil(f/multiple) * multiple), nil
 }
 
 func absFunction(args ...interface{}) (interface{}, error) {

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -52,6 +52,8 @@ var functions = map[string]govaluate.ExpressionFunction{
 	"floor":       floorFunction,
 	"CEILING":     ceilingFunction,
 	"ceiling":     ceilingFunction,
+	"trunc":       truncFunction,
+	"TRUNC":       truncFunction,
 	"SAFE_DIV":    safeDivFuntion,
 	"Safe_div":    safeDivFuntion,
 	"safe_div":    safeDivFuntion,
@@ -161,6 +163,20 @@ func ceilingFunction(args ...interface{}) (interface{}, error) {
 	}
 	f := args[0].(float64)
 	return (math.Ceil(f/multiple) * multiple), nil
+}
+
+// TRUNC https://support.office.com/en-us/article/trunc-function-8b86a64c-3127-43db-ba14-aa5ceb292721
+// by default 0 digits after the decimal
+// but can passed an optional argument to ask for more
+func truncFunction(args ...interface{}) (interface{}, error) {
+	places := 0
+	if len(args) == 2 {
+		places = int(args[1].(float64))
+	}
+	f := args[0].(float64)
+
+	shift := math.Pow(10, float64(places))
+	return (float64(int(f*shift)) / shift), nil
 }
 
 func absFunction(args ...interface{}) (interface{}, error) {

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -44,10 +44,10 @@ func TestGeneric(t *testing.T) {
 		{"floor", []interface{}{33.3333333, 10.0}, 30.0},
 		{"floor", []interface{}{-33.3333333, 10.0}, -40.0},
 
-		{"ceil", []interface{}{33.3333333}, 34.0},
-		{"ceil", []interface{}{-33.3333333}, -33.0},
-		{"ceil", []interface{}{33.3333333, 10.0}, 40.0},
-		{"ceil", []interface{}{-33.3333333, 10.0}, -30.0},
+		{"ceiling", []interface{}{33.3333333}, 34.0},
+		{"ceiling", []interface{}{-33.3333333}, -33.0},
+		{"ceiling", []interface{}{33.3333333, 10.0}, 40.0},
+		{"ceiling", []interface{}{-33.3333333, 10.0}, -30.0},
 
 		{"abs", []interface{}{1.0}, 1.0},
 		{"abs", []interface{}{-1.0}, 1.0},

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -49,6 +49,14 @@ func TestGeneric(t *testing.T) {
 		{"ceiling", []interface{}{33.3333333, 10.0}, 40.0},
 		{"ceiling", []interface{}{-33.3333333, 10.0}, -30.0},
 
+		{"trunc", []interface{}{1.2345678}, 1.0},
+		{"trunc", []interface{}{-1.2345678}, -1.0},
+		{"trunc", []interface{}{1.2345678, 2.0}, 1.23},
+		{"trunc", []interface{}{1.2345678, 3.0}, 1.234},
+		{"trunc", []interface{}{1.2345678, 4.0}, 1.2345},
+		{"trunc", []interface{}{1.2345678, 5.0}, 1.23456},
+		{"round", []interface{}{1.2345678, 5.0}, 1.23457},
+
 		{"abs", []interface{}{1.0}, 1.0},
 		{"abs", []interface{}{-1.0}, 1.0},
 

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -39,6 +39,16 @@ func TestGeneric(t *testing.T) {
 		{"round", []interface{}{33.3333333}, 33.0},
 		{"round", []interface{}{33.3333333, 2.0}, 33.33},
 
+		{"floor", []interface{}{33.3333333}, 33.0},
+		{"floor", []interface{}{-33.3333333}, -34.0},
+		{"floor", []interface{}{33.3333333, 10.0}, 30.0},
+		{"floor", []interface{}{-33.3333333, 10.0}, -40.0},
+
+		{"ceil", []interface{}{33.3333333}, 34.0},
+		{"ceil", []interface{}{-33.3333333}, -33.0},
+		{"ceil", []interface{}{33.3333333, 10.0}, 40.0},
+		{"ceil", []interface{}{-33.3333333, 10.0}, -30.0},
+
 		{"abs", []interface{}{1.0}, 1.0},
 		{"abs", []interface{}{-1.0}, 1.0},
 


### PR DESCRIPTION
try to mimic :
  - FLOOR https://support.office.com/en-us/article/floor-function-14bb497c-24f2-4e04-b327-b0b4de5a8886
  - CEILING https://support.office.com/en-us/article/ceiling-function-0a5cd7c8-0720-4f0a-bd2c-c943e510899f

by default floor or ceil to nearest multiple of 1.0
but can be passed as an optional argument find another "nearest" multiple

 -  TRUNC https://support.office.com/en-us/article/trunc-function-8b86a64c-3127-43db-ba14-aa5ceb292721
by default 0 digits after the decimal but can passed an optional argument to ask for more
