### PR TITLE
Go 1.18 and using any instead of interface{}

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/BLSQ/go-hesabu
 
+                               go 1.18
+
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/gleicon/go-descriptive-statistics v0.0.0-20130529112640-b8e9f79bb7ee

--- a/hesabu.go
+++ b/hesabu.go
@@ -96,14 +96,14 @@ You need to either supply a filename or pipe to hesabu
 }
 
 func logErrors(errors []hesabu.EvalError) {
-	var content = make(map[string]interface{}, 1)
+	var content = make(map[string]any, 1)
 	content["errors"] = errors
 	b, _ := json.MarshalIndent(content, "", "  ")
 	s := string(b)
 	fmt.Println(s)
 }
 
-func logSolution(solutions map[string]interface{}) {
+func logSolution(solutions map[string]any) {
 	b, err := json.MarshalIndent(solutions, "", "  ")
 	if err != nil {
 		logErrors([]hesabu.EvalError{

--- a/hesabu/parser.go
+++ b/hesabu/parser.go
@@ -60,10 +60,10 @@ func Parse(rawEquations map[string]string, functions map[string]govaluate.Expres
 }
 
 // Solve the equation in correct order and return map of values
-func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
+func (parsedEquations ParsedEquations) Solve() (map[string]any, error) {
 	topsort := toposort.ReversedSort(parsedEquations.Dependencies)
 
-	solutions := make(map[string]interface{}, len(parsedEquations.RawEquations))
+	solutions := make(map[string]any, len(parsedEquations.RawEquations))
 	if len(topsort) == 0 {
 		evalError := EvalError{Message: "cycle between equations", Source: "general", Expression: "general"}
 		return nil, &CustomError{EvalError: evalError}
@@ -99,7 +99,7 @@ func (parsedEquations ParsedEquations) Solve() (map[string]interface{}, error) {
 	return solutions, nil
 }
 
-func (parsedEquations ParsedEquations) newSingleError(key string, message string) (map[string]interface{}, error) {
+func (parsedEquations ParsedEquations) newSingleError(key string, message string) (map[string]any, error) {
 	equation := parsedEquations.RawEquations[key]
 	evalError := EvalError{Message: message, Source: key, Expression: equation}
 	return nil, &CustomError{EvalError: evalError}

--- a/hesabu/parser_test.go
+++ b/hesabu/parser_test.go
@@ -11,7 +11,7 @@ type ParserTest struct {
 	Input              string
 	Expected           string
 	ParserErrorMessage string
-	Solution           interface{}
+	Solution           any
 	SolutionError      string
 }
 

--- a/hesabu/registry.go
+++ b/hesabu/registry.go
@@ -70,7 +70,7 @@ var functions = map[string]govaluate.ExpressionFunction{
 	"cal_days_in_month": calDaysInMonth,
 }
 
-func randbetweenFunction(args ...interface{}) (interface{}, error) {
+func randbetweenFunction(args ...any) (any, error) {
 	min := args[0].(float64)
 	max := args[1].(float64)
 	result := min + rand.Float64()*(max-min)
@@ -86,7 +86,7 @@ func randbetweenFunction(args ...interface{}) (interface{}, error) {
 	matching_rules.last
   end
 */
-func scoreTableFunction(args ...interface{}) (interface{}, error) {
+func scoreTableFunction(args ...any) (any, error) {
 	target := args[0].(float64)
 	rules := args[1:]
 	chunkSize := 3
@@ -121,7 +121,7 @@ func scoreTableFunction(args ...interface{}) (interface{}, error) {
 // access(ARRAY(1,2,0)) => 1
 //
 // If the index is out of range an error will be returned.
-func accessFunction(args ...interface{}) (interface{}, error) {
+func accessFunction(args ...any) (any, error) {
 	index := int(args[len(args)-1].(float64))
 	if index > len(args)-1 {
 		return nil, &customFunctionError{
@@ -133,14 +133,14 @@ func accessFunction(args ...interface{}) (interface{}, error) {
 	return args[index], nil
 }
 
-func getShiftPlaces(args []interface{}) float64 {
+func getShiftPlaces(args []any) float64 {
 	places := int(getSecondArgsAsFloat(args, 0.0))
 
 	shift := math.Pow(10, float64(places))
 	return shift
 }
 
-func getSecondArgsAsFloat(args []interface{}, defaultValue float64) float64 {
+func getSecondArgsAsFloat(args []any, defaultValue float64) float64 {
 	value := defaultValue
 	if len(args) == 2 {
 		value = args[1].(float64)
@@ -148,7 +148,7 @@ func getSecondArgsAsFloat(args []interface{}, defaultValue float64) float64 {
 	return value
 }
 
-func roundFunction(args ...interface{}) (interface{}, error) {
+func roundFunction(args ...any) (any, error) {
 	shift := getShiftPlaces(args)
 	f := args[0].(float64)
 	return (math.Round(f*shift) / shift), nil
@@ -157,7 +157,7 @@ func roundFunction(args ...interface{}) (interface{}, error) {
 // mimic FLOOR https://support.office.com/en-us/article/floor-function-14bb497c-24f2-4e04-b327-b0b4de5a8886
 // by default floor to nearest multiple of 1.0
 // but can be passed as an optional argument
-func floorFunction(args ...interface{}) (interface{}, error) {
+func floorFunction(args ...any) (any, error) {
 	multiple := getSecondArgsAsFloat(args, 1.0)
 	f := args[0].(float64)
 	return (math.Floor(f/multiple) * multiple), nil
@@ -166,7 +166,7 @@ func floorFunction(args ...interface{}) (interface{}, error) {
 // CEILING https://support.office.com/en-us/article/ceiling-function-0a5cd7c8-0720-4f0a-bd2c-c943e510899f
 // by default ceil to nearest multiple of 1.0
 // but can be passed as an optional argument
-func ceilingFunction(args ...interface{}) (interface{}, error) {
+func ceilingFunction(args ...any) (any, error) {
 	multiple := getSecondArgsAsFloat(args, 1.0)
 	f := args[0].(float64)
 	return (math.Ceil(f/multiple) * multiple), nil
@@ -175,17 +175,17 @@ func ceilingFunction(args ...interface{}) (interface{}, error) {
 // TRUNC https://support.office.com/en-us/article/trunc-function-8b86a64c-3127-43db-ba14-aa5ceb292721
 // by default 0 digits after the decimal
 // but can passed an optional argument to ask for more
-func truncFunction(args ...interface{}) (interface{}, error) {
+func truncFunction(args ...any) (any, error) {
 	shift := getShiftPlaces(args)
 	f := args[0].(float64)
 	return (float64(int(f*shift)) / shift), nil
 }
 
-func absFunction(args ...interface{}) (interface{}, error) {
+func absFunction(args ...any) (any, error) {
 	return math.Abs(args[0].(float64)), nil
 }
 
-func sqrtFunction(args ...interface{}) (interface{}, error) {
+func sqrtFunction(args ...any) (any, error) {
 	float, ok := args[0].(float64)
 	if !ok {
 		return nil, &customFunctionError{
@@ -202,8 +202,8 @@ func sqrtFunction(args ...interface{}) (interface{}, error) {
 	return math.Sqrt(float), nil
 }
 
-func ifFunction(args ...interface{}) (interface{}, error) {
-	var result interface{}
+func ifFunction(args ...any) (any, error) {
+	var result any
 	bool, ok := args[0].(bool)
 	if !ok {
 		return nil, &customFunctionError{
@@ -220,14 +220,14 @@ func ifFunction(args ...interface{}) (interface{}, error) {
 	return result, nil
 }
 
-func safeDivFuntion(args ...interface{}) (interface{}, error) {
+func safeDivFuntion(args ...any) (any, error) {
 	if args[1].(float64) == 0 {
 		return float64(0), nil
 	}
 	return (args[0].(float64) / args[1].(float64)), nil
 }
 
-func maxFunction(args ...interface{}) (interface{}, error) {
+func maxFunction(args ...any) (any, error) {
 	max := args[0].(float64)
 	for _, arg := range args {
 		if arg.(float64) > max {
@@ -237,7 +237,7 @@ func maxFunction(args ...interface{}) (interface{}, error) {
 	return max, nil
 }
 
-func minFunction(args ...interface{}) (interface{}, error) {
+func minFunction(args ...any) (any, error) {
 	min := args[0].(float64)
 	for _, arg := range args {
 		if arg.(float64) < min {
@@ -247,7 +247,7 @@ func minFunction(args ...interface{}) (interface{}, error) {
 	return min, nil
 }
 
-func sumFunction(args ...interface{}) (interface{}, error) {
+func sumFunction(args ...any) (any, error) {
 	total := float64(0.0)
 	for _, a := range args {
 		if v, ok := a.(float64); ok {
@@ -262,7 +262,7 @@ func sumFunction(args ...interface{}) (interface{}, error) {
 	return total, nil
 }
 
-func stdevFunction(args ...interface{}) (interface{}, error) {
+func stdevFunction(args ...any) (any, error) {
 	values := make(descriptive_statistics.Enum, len(args))
 	for i := range args {
 		values[i] = args[i].(float64)
@@ -274,7 +274,7 @@ func stdevFunction(args ...interface{}) (interface{}, error) {
 // dentaku, so arrays can be explicilty marked as arrays.
 //
 // ARRAY(1,2,3) => (1,2,3)
-func arrayFunction(args ...interface{}) (interface{}, error) {
+func arrayFunction(args ...any) (any, error) {
 	return args, nil
 }
 
@@ -291,7 +291,7 @@ func arrayFunction(args ...interface{}) (interface{}, error) {
 //
 //       (2-1, 3-2,4-3)
 //       (1,1,1)
-func evalArrayFunction(args ...interface{}) (interface{}, error) {
+func evalArrayFunction(args ...any) (any, error) {
 	key1 := args[0].(string)
 	array1 := ensureSlice(args[1])
 	key2 := args[2].(string)
@@ -322,10 +322,10 @@ func evalArrayFunction(args ...interface{}) (interface{}, error) {
 			err:          fmt.Sprintf("Meta formula: %v", err),
 		}
 	}
-	var results []interface{}
+	var results []any
 	for i, item1 := range array1 {
 		item2 := array2[i]
-		parameters := make(map[string]interface{}, 2)
+		parameters := make(map[string]any, 2)
 		parameters[key1] = item1
 		parameters[key2] = item2
 		result, error_eval := expression.Evaluate(parameters)
@@ -341,7 +341,7 @@ func evalArrayFunction(args ...interface{}) (interface{}, error) {
 	return results, nil
 }
 
-func averageFunction(args ...interface{}) (interface{}, error) {
+func averageFunction(args ...any) (any, error) {
 	total := float64(0)
 	for _, x := range args {
 		total += x.(float64)
@@ -349,12 +349,12 @@ func averageFunction(args ...interface{}) (interface{}, error) {
 	return (total / float64(len(args))), nil
 }
 
-func strlen(args ...interface{}) (interface{}, error) {
+func strlen(args ...any) (any, error) {
 	length := len(args[0].(string))
 	return (float64)(length), nil
 }
 
-func calDaysInMonth(args ...interface{}) (interface{}, error) {
+func calDaysInMonth(args ...any) (any, error) {
 	year, err := asInt(args[0], "CAL_DAYS_IN_MONTH()")
 	if err != nil {
 		return nil, err
@@ -381,7 +381,7 @@ func calDaysInMonth(args ...interface{}) (interface{}, error) {
 	return float64(lastDayMonth.Day()), nil
 }
 
-func asInt(arg interface{}, functionName string) (int, error) {
+func asInt(arg any, functionName string) (int, error) {
 	switch t := arg.(type) {
 	case float64:
 		return int(t), nil
@@ -400,10 +400,10 @@ func asDate(year, month, day int) time.Time {
 
 // Ensures that the interface passed is a slice, it's like Array.wrap
 // but in golang.
-func ensureSlice(arg interface{}) []interface{} {
-	arr, ok := arg.([]interface{})
+func ensureSlice(arg any) []any {
+	arr, ok := arg.([]any)
 	if !ok {
-		arr = make([]interface{}, 1)
+		arr = make([]any, 1)
 		arr[0] = arg
 	}
 	return arr

--- a/hesabu/registry_test.go
+++ b/hesabu/registry_test.go
@@ -8,68 +8,68 @@ import (
 func TestGeneric(t *testing.T) {
 	tables := []struct {
 		functionToCall string
-		args           []interface{}
-		expected       interface{}
+		args           []any
+		expected       any
 	}{
-		{"max", []interface{}{4.0, 1.0}, 4.0},
-		{"max", []interface{}{1.0, 5.0}, 5.0},
-		{"max", []interface{}{-1.0, 5.0}, 5.0},
-		{"max", []interface{}{-1.0, -2.0}, -1.0},
+		{"max", []any{4.0, 1.0}, 4.0},
+		{"max", []any{1.0, 5.0}, 5.0},
+		{"max", []any{-1.0, 5.0}, 5.0},
+		{"max", []any{-1.0, -2.0}, -1.0},
 
-		{"min", []interface{}{4.0, 1.0}, 1.0},
-		{"min", []interface{}{2.0, 5.0}, 2.0},
-		{"min", []interface{}{-1.0, 5.0}, -1.0},
-		{"min", []interface{}{-1.0, -2.0}, -2.0},
+		{"min", []any{4.0, 1.0}, 1.0},
+		{"min", []any{2.0, 5.0}, 2.0},
+		{"min", []any{-1.0, 5.0}, -1.0},
+		{"min", []any{-1.0, -2.0}, -2.0},
 
-		{"score_table", []interface{}{1.0, 0.0, 2.0, 50.0, 2.0, 10.0, 95.0}, 50.0},
-		{"score_table", []interface{}{3.0, 0.0, 2.0, 50.0, 2.0, 10.0, 95.0}, 95.0},
+		{"score_table", []any{1.0, 0.0, 2.0, 50.0, 2.0, 10.0, 95.0}, 50.0},
+		{"score_table", []any{3.0, 0.0, 2.0, 50.0, 2.0, 10.0, 95.0}, 95.0},
 
-		{"safe_div", []interface{}{1.0, 0.0}, 0.0},
-		{"safe_div", []interface{}{8.0, 2.0}, 4.0},
+		{"safe_div", []any{1.0, 0.0}, 0.0},
+		{"safe_div", []any{8.0, 2.0}, 4.0},
 
-		{"if", []interface{}{true, 9000, 3}, 9000},
-		{"if", []interface{}{false, 2, 9000}, 9000},
+		{"if", []any{true, 9000, 3}, 9000},
+		{"if", []any{false, 2, 9000}, 9000},
 
-		{"avg", []interface{}{1.0, 2.0, 3.0}, 2.0},
+		{"avg", []any{1.0, 2.0, 3.0}, 2.0},
 
-		{"sum", []interface{}{1.0, 2.0, 3.0}, 6.0},
+		{"sum", []any{1.0, 2.0, 3.0}, 6.0},
 
-		{"stdevp", []interface{}{1.0, 2.0, 13.0, 3.0, 7.0, 9.0}, 4.258977446393546},
+		{"stdevp", []any{1.0, 2.0, 13.0, 3.0, 7.0, 9.0}, 4.258977446393546},
 
-		{"round", []interface{}{33.3333333}, 33.0},
-		{"round", []interface{}{33.3333333, 2.0}, 33.33},
+		{"round", []any{33.3333333}, 33.0},
+		{"round", []any{33.3333333, 2.0}, 33.33},
 
-		{"floor", []interface{}{33.3333333}, 33.0},
-		{"floor", []interface{}{-33.3333333}, -34.0},
-		{"floor", []interface{}{33.3333333, 10.0}, 30.0},
-		{"floor", []interface{}{-33.3333333, 10.0}, -40.0},
+		{"floor", []any{33.3333333}, 33.0},
+		{"floor", []any{-33.3333333}, -34.0},
+		{"floor", []any{33.3333333, 10.0}, 30.0},
+		{"floor", []any{-33.3333333, 10.0}, -40.0},
 
-		{"ceiling", []interface{}{33.3333333}, 34.0},
-		{"ceiling", []interface{}{-33.3333333}, -33.0},
-		{"ceiling", []interface{}{33.3333333, 10.0}, 40.0},
-		{"ceiling", []interface{}{-33.3333333, 10.0}, -30.0},
+		{"ceiling", []any{33.3333333}, 34.0},
+		{"ceiling", []any{-33.3333333}, -33.0},
+		{"ceiling", []any{33.3333333, 10.0}, 40.0},
+		{"ceiling", []any{-33.3333333, 10.0}, -30.0},
 
-		{"trunc", []interface{}{1.2345678}, 1.0},
-		{"trunc", []interface{}{-1.2345678}, -1.0},
-		{"trunc", []interface{}{1.2345678, 2.0}, 1.23},
-		{"trunc", []interface{}{1.2345678, 3.0}, 1.234},
-		{"trunc", []interface{}{1.2345678, 4.0}, 1.2345},
-		{"trunc", []interface{}{1.2345678, 5.0}, 1.23456},
-		{"round", []interface{}{1.2345678, 5.0}, 1.23457},
+		{"trunc", []any{1.2345678}, 1.0},
+		{"trunc", []any{-1.2345678}, -1.0},
+		{"trunc", []any{1.2345678, 2.0}, 1.23},
+		{"trunc", []any{1.2345678, 3.0}, 1.234},
+		{"trunc", []any{1.2345678, 4.0}, 1.2345},
+		{"trunc", []any{1.2345678, 5.0}, 1.23456},
+		{"round", []any{1.2345678, 5.0}, 1.23457},
 
-		{"abs", []interface{}{1.0}, 1.0},
-		{"abs", []interface{}{-1.0}, 1.0},
+		{"abs", []any{1.0}, 1.0},
+		{"abs", []any{-1.0}, 1.0},
 
-		{"sqrt", []interface{}{4.0}, 2.0},
+		{"sqrt", []any{4.0}, 2.0},
 
-		{"access", []interface{}{1.0, 2.0, 3.0, 1.0}, 2.0},
-		{"access", []interface{}{1.0, 2.0, 3.0, 2.0}, 3.0},
+		{"access", []any{1.0, 2.0, 3.0, 1.0}, 2.0},
+		{"access", []any{1.0, 2.0, 3.0, 2.0}, 3.0},
 
-		{"strlen", []interface{}{"1234567"}, 7.0},
+		{"strlen", []any{"1234567"}, 7.0},
 
-		{"cal_days_in_month", []interface{}{2020.0, 2.0}, 29.0},
-		{"cal_days_in_month", []interface{}{2020, 2}, 29.0},
-		{"cal_days_in_month", []interface{}{2020, 12}, 31.0},
+		{"cal_days_in_month", []any{2020.0, 2.0}, 29.0},
+		{"cal_days_in_month", []any{2020, 2}, 29.0},
+		{"cal_days_in_month", []any{2020, 12}, 31.0},
 	}
 
 	for _, table := range tables {
@@ -93,7 +93,7 @@ func TestGeneric(t *testing.T) {
 }
 
 func TestSqrtFunctionWithIncorrectBool(t *testing.T) {
-	inputData := []interface{}{true}
+	inputData := []any{true}
 	_, err := Functions()["sqrt"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -102,7 +102,7 @@ func TestSqrtFunctionWithIncorrectBool(t *testing.T) {
 }
 
 func TestSqrtFunctionWithIncorrectNegative(t *testing.T) {
-	inputData := []interface{}{-1.0}
+	inputData := []any{-1.0}
 	_, err := Functions()["sqrt"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -111,7 +111,7 @@ func TestSqrtFunctionWithIncorrectNegative(t *testing.T) {
 }
 
 func TestIfFunctionWithIncorrectBool(t *testing.T) {
-	inputData := []interface{}{1, 2, 3}
+	inputData := []any{1, 2, 3}
 	_, err := Functions()["IF"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -120,7 +120,7 @@ func TestIfFunctionWithIncorrectBool(t *testing.T) {
 }
 
 func TestSumFunctionWithIncorrectValues(t *testing.T) {
-	inputData := []interface{}{"a", "b", "c"}
+	inputData := []any{"a", "b", "c"}
 	_, err := Functions()["SUM"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -129,7 +129,7 @@ func TestSumFunctionWithIncorrectValues(t *testing.T) {
 }
 
 func TestRandBetweenFunction(t *testing.T) {
-	inputData := []interface{}{1.0, 10.0}
+	inputData := []any{1.0, 10.0}
 	value, err := Functions()["randbetween"](inputData...)
 	if err != nil {
 		t.Logf("randbetween shouldn't return error")
@@ -155,7 +155,7 @@ func TestBothUpperCaseAndLowerCaseVariantsAreFound(t *testing.T) {
 }
 
 func TestAccessOutOfRangeError(t *testing.T) {
-	inputData := []interface{}{1.0, 2.0, 8.0}
+	inputData := []any{1.0, 2.0, 8.0}
 	_, err := Functions()["access"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -164,7 +164,7 @@ func TestAccessOutOfRangeError(t *testing.T) {
 }
 
 func TestCalDaysInMonthInvalidYear(t *testing.T) {
-	inputData := []interface{}{1.0, 2.0}
+	inputData := []any{1.0, 2.0}
 	_, err := Functions()["cal_days_in_month"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -173,7 +173,7 @@ func TestCalDaysInMonthInvalidYear(t *testing.T) {
 }
 
 func TestCalDaysInMonthInvalidMonthLower(t *testing.T) {
-	inputData := []interface{}{2020.0, 0}
+	inputData := []any{2020.0, 0}
 	_, err := Functions()["cal_days_in_month"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -182,7 +182,7 @@ func TestCalDaysInMonthInvalidMonthLower(t *testing.T) {
 }
 
 func TestCalDaysInMonthInvalidMonthGreater(t *testing.T) {
-	inputData := []interface{}{2020.0, 13}
+	inputData := []any{2020.0, 13}
 	_, err := Functions()["cal_days_in_month"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)
@@ -191,7 +191,7 @@ func TestCalDaysInMonthInvalidMonthGreater(t *testing.T) {
 }
 
 func TestCalDaysInMonthInvalidMontType(t *testing.T) {
-	inputData := []interface{}{2020.0, "a"}
+	inputData := []any{2020.0, "a"}
 	_, err := Functions()["cal_days_in_month"](inputData...)
 	if err, ok := err.(*customFunctionError); !ok {
 		t.Logf("else, %v", err)


### PR DESCRIPTION
Go 1.18 had performance upgrades for the M1 processors, so I wanted to try that out. So this is is an upgrade to 1.18 and then I did a `gofmt -r 'interface{} -> any' -w  hesabu.go hesabu/*.go` because that is now a thing.

It is faster on my machine, but I did not test it nearly enough to make it a proper PR.